### PR TITLE
cli/pr: Allow missing _test.go files

### DIFF
--- a/cmd/tctest/cli/pr.go
+++ b/cmd/tctest/cli/pr.go
@@ -65,7 +65,8 @@ func PrTests(repo, pr, fileRegExStr, splitTestsAt string) (*[]string, error) {
 	for f := range filesm {
 		tests, err := PrFileTests(repo, sha, f)
 		if err != nil {
-			return nil, fmt.Errorf("Error fetching tests: %v", err)
+			common.Log.Warningf("unable to fetch tests from file (%s): %v", f, err)
+			continue
 		}
 
 		for _, t := range tests {


### PR DESCRIPTION
Closes #1

The `pr` command required all Go source files to have a `_test.go` counterpart. This updates the command's behavior to instead provide a warning log message and go to the next file.

Previously:

```console
$ tctest pr 8916
Discovering tests for pr #8916 (https://github.com/terraform-providers/terraform-provider-aws/pull/8916)...
Usage:
  tctest pr # [test_regex] [flags]
  tctest pr [command]

Available Commands:
  list        attempts to discover what acceptance tests to run for a PR

Flags:
  -h, --help   help for pr

Global Flags:
  -b, --buildtypeid string   the TeamCity BuildTypeId to trigger
      --fileregex string     the regex to filter files by` (default "(^[a-z]*/resource_|^[a-z]*/data_source_)")
  -p, --pass string          the TeamCity password to use (consider exporting pass to TCTEST_PASS instead)
  -r, --repo string          repository the pr resides in, such as terraform-providers/terraform-provider-azurerm
  -s, --server string        the TeamCity server's ur;
      --splittests string    split tests here and use the value on the left (default "_")
  -u, --user string          the TeamCity user to use

Use "tctest pr [command] --help" for more information about a command.

ERRO[2019-06-10 08:01:24] tctest: pr cmd failed: pr list failed: Error fetching tests: unable to get content from https://raw.githubusercontent.com/terraform-providers/terraform-provider-aws/49cbf754b761ca9f707775a82df87a342fb81f8d/aws/resource_aws_lex_test.go: HTTP status NOT OK: 404
```

Now:

```console
$ tctest pr 8916
Discovering tests for pr #8916 (https://github.com/terraform-providers/terraform-provider-aws/pull/8916)...
WARN[2019-06-10 08:36:17] unable to fetch tests from file (aws/resource_aws_lex_test.go): unable to get content from https://raw.githubusercontent.com/terraform-providers/terraform-provider-aws/49cbf754b761ca9f707775a82df87a342fb81f8d/aws/resource_aws_lex_test.go: HTTP status NOT OK: 404
    TestAccLexSlotType
    TestAccDataSourceAwsLexSlotType
triggering refs/pull/8916/merge for (TestAccLexSlotType|TestAccDataSourceAwsLexSlotType)...
  bflad@--OMITTED--#Aws_ProviderAws
  build 60540 queued! (https://--OMITTED--/viewQueued.html?itemId=60540)
```