### PR TITLE
cmd/status: Return results of subtests

### DIFF
--- a/cmd/tctest/cli/tc.go
+++ b/cmd/tctest/cli/tc.go
@@ -100,7 +100,7 @@ func TcTestStatus(server, buildId, user, pass string) error {
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
-	r, err := regexp.Compile("^--- (FAIL|PASS|SKIP):")
+	r := regexp.MustCompile(`^\s*--- (FAIL|PASS|SKIP):`)
 	for scanner.Scan() {
 		if r.MatchString(scanner.Text()) {
 			fmt.Println(scanner.Text())


### PR DESCRIPTION
Closes #8

Previously, the command would only return the top level test results for nested tests:

```console
$ tctest status 87870

--- PASS: TestAccAWSAccessAnalyzer (31.50s)
```

Now, the command will show the top level test and any nested subtests:

```console
$ make build
==> building...
cd cmd/tctest && go build -ldflags "-X github.com/katbyte/tctest/version.GitCommit=e203ffd-dirty" . && mv tctest ../../
$ ./tctest master TestAccAWSAccessAnalyzer
triggering refs/heads/master for TestAccAWSAccessAnalyzer...
  bflad@--OMITTED--#Aws_ProviderAwsAlternate
  build 90325 queued! (https://--OMITTED--/viewQueued.html?itemId=90325)
$ ./tctest status 90325
--- PASS: TestAccAWSAccessAnalyzer (31.97s)
    --- PASS: TestAccAWSAccessAnalyzer/Analyzer (31.97s)
        --- PASS: TestAccAWSAccessAnalyzer/Analyzer/basic (8.11s)
        --- PASS: TestAccAWSAccessAnalyzer/Analyzer/disappears (6.02s)
        --- PASS: TestAccAWSAccessAnalyzer/Analyzer/Tags (17.85s)
```

This also switches the implementation from `regexp.Compile()` to `regexp.MustCompile()` since the provided regular expression is static and should panic on compilation instead of returning an unhandled error.