### PR TITLE
Merge pull request #12 from bflad/td-remove-http-client-timeout

### DIFF
--- a/common/http.go
+++ b/common/http.go
@@ -6,12 +6,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"time"
 )
 
-var Http = &http.Client{
-	Timeout: time.Second * 10,
-}
+var Http = http.DefaultClient
 
 func HttpGetReader(url string) (*io.ReadCloser, error) {
 	Log.Debug("HTTP GET: " + url)


### PR DESCRIPTION
Closes #7

Reference: https://golang.org/pkg/net/http/#Client

```
    // Timeout specifies a time limit for requests made by this
    // Client. The timeout includes connection time, any
    // redirects, and reading the response body. The timer remains
    // running after Get, Head, Post, or Do return and will
    // interrupt reading of the Response.Body.
```

Interrupting the reading of the `Response.Body` seems less than ideal so quickly, especially on slower connections, since `tctest status` responses can be MBs of log file. If connection tuning is desired beyond the fairly reasonable default timeouts of `net.Dialer` at 30 seconds and `TLSHandshakeTImeout` at 10 seconds (https://golang.org/pkg/net/http/#RoundTripper), we may want to tune those specifically instead within the client `Transport`.