### PR TITLE
command/pr: Prevent auto-detection running all tests unexpectedly

### DIFF
--- a/cmd/tctest/cli/cmds.go
+++ b/cmd/tctest/cli/cmds.go
@@ -135,6 +135,10 @@ Complete documentation is available at https://github.com/katbyte/tctest`,
 					return fmt.Errorf("pr cmd failed: %v", err)
 				}
 
+				if tests == nil || len(*tests) == 0 {
+					return fmt.Errorf("unable to automatically find tests (starting with Test). Cancelling to prevent running all tests unexpectedly. If you wish to run a specific test pattern or all tests, provide an explicit test pattern.")
+				}
+
 				testRegEx = "(" + strings.Join(*tests, "|") + ")"
 			}
 


### PR DESCRIPTION
Closes #27

Previously:

```console
$ tctest pr 13270
Discovering tests for pr #13270 (https://github.com/terraform-providers/terraform-provider-aws/pull/13270)...
triggering refs/pull/13270/merge for ()...
  bflad@--OMITTED--#Aws_ProviderAwsOrganizations
  build 112841 queued: https://--OMITTED--/viewQueued.html?itemId=112841
```

Now:

```console
$ tctest pr 13270
Discovering tests for pr #13270 (https://github.com/terraform-providers/terraform-provider-aws/pull/13270)...
ERRO[2020-05-13 08:50:56] tctest: unable to automatically find tests (starting with Test). Cancelling to prevent running all tests unexpectedly. If you wish to run a specific test pattern or all tests, provide an explicit test pattern.
```