### PR TITLE
command/pr-results: support returning test results by github pr number

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ tctest results 12345 --wait
 
 To show the PASS/FAIL/SKIP results for **all** TeamCity builds for a Github PR:
 ```bash
-tctest pr-results 12345
+tctest results pr 12345
 ```
 To show the PASS/FAIL/SKIP results for the **latest** TeamCity build for a Github PR:
 ```bash
-tctest pr-results 12345 --latest
+tctest results pr 12345 --latest
 ```
 To wait for a running or queued build to complete and then show the results:
 ```bash
-tctest pr-results 12345 --wait
+tctest results pr 12345 --wait
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ To run tests against a PR and display results when complete:
 tctest pr 3232 --wait
 ```
 
-## Build results
+## Build results: 
+*By TeamCity Build Number*
 
 To show the PASS/FAIL/SKIP results for a TeamCity build number:
 ```bash
@@ -64,4 +65,19 @@ tctest results 12345
 To wait for a running or queued build to complete and then show the results:
 ```bash
 tctest results 12345 --wait
+```
+
+*By Github PR Number*
+
+To show the PASS/FAIL/SKIP results for **all** TeamCity builds for a Github PR:
+```bash
+tctest pr-results 12345
+```
+To show the PASS/FAIL/SKIP results for the **latest** TeamCity build for a Github PR:
+```bash
+tctest pr-results 12345 --latest
+```
+To wait for a running or queued build to complete and then show the results:
+```bash
+tctest pr-results 12345 --wait
 ```

--- a/cmd/tctest/cli/tc.go
+++ b/cmd/tctest/cli/tc.go
@@ -201,10 +201,10 @@ func (tc TeamCity) testResultsByPR(pr, buildTypeId string, latest, wait bool) er
 
 		if build.State == "running" && !wait {
 			// If we didn't want to wait and it's not finished, print a warning at the end so people notice it
-			return fmt.Errorf("build (ID: %s) for PR %s is still running, test results may be incomplete", build.ID, pr)
+			fmt.Errorf("build (ID: %s) for PR %s is still running, test results may be incomplete\n", build.ID, pr)
 		}
 
-		fmt.Printf("Complete Build Log: %s\n\n", build.WebURL)
+		fmt.Printf("Build Log: %s\n\n", build.WebURL)
 	}
 
 	return nil

--- a/cmd/tctest/cli/tc.go
+++ b/cmd/tctest/cli/tc.go
@@ -201,7 +201,7 @@ func (tc TeamCity) testResultsByPR(pr, buildTypeId string, latest, wait bool) er
 
 		if build.State == "running" && !wait {
 			// If we didn't want to wait and it's not finished, print a warning at the end so people notice it
-			fmt.Errorf("build (ID: %s) for PR %s is still running, test results may be incomplete\n", build.ID, pr)
+			fmt.Printf("[WARN] build (ID: %s) for PR %s is still running, test results may be incomplete\n", build.ID, pr)
 		}
 
 		fmt.Printf("Build Log: %s\n\n", build.WebURL)


### PR DESCRIPTION
Closes #29 

* Some refactoring as well since `TcTestResults` looks similar 😄 

Example usage and results:
```
tctest results pr 13337 -s ci.example.com -u angie -b providerName --latest
```

```
Test Results (buildID: xxxxx, buildNumber: xxxxxx, branch: /pull/13337/merge):
--- FAIL: TestAccAWSAppmesh (261.42s)
    --- PASS: TestAccAWSAppmesh/Mesh (41.09s)
        --- PASS: TestAccAWSAppmesh/Mesh/tags (18.01s)
        --- PASS: TestAccAWSAppmesh/Mesh/basic (7.44s)
        --- PASS: TestAccAWSAppmesh/Mesh/egressFilter (15.64s)
    --- FAIL: TestAccAWSAppmesh/Route (28.01s)
        --- FAIL: TestAccAWSAppmesh/Route/tcpRoute (5.78s)
        --- FAIL: TestAccAWSAppmesh/Route/routePriority (5.45s)
        --- FAIL: TestAccAWSAppmesh/Route/tags (5.44s)
        --- FAIL: TestAccAWSAppmesh/Route/httpHeader (5.69s)
        --- FAIL: TestAccAWSAppmesh/Route/httpRoute (5.66s)
    --- FAIL: TestAccAWSAppmesh/VirtualNode (144.90s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/basic (17.88s)
        --- FAIL: TestAccAWSAppmesh/VirtualNode/cloudMapServiceDiscovery (90.34s)
        --- FAIL: TestAccAWSAppmesh/VirtualNode/listenerHealthChecks (14.41s)
        --- FAIL: TestAccAWSAppmesh/VirtualNode/logging (4.35s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/tags (17.91s)
    --- FAIL: TestAccAWSAppmesh/VirtualRouter (10.01s)
        --- FAIL: TestAccAWSAppmesh/VirtualRouter/basic (4.59s)
        --- FAIL: TestAccAWSAppmesh/VirtualRouter/tags (5.42s)
    --- FAIL: TestAccAWSAppmesh/VirtualService (37.40s)
        --- PASS: TestAccAWSAppmesh/VirtualService/virtualNode (13.37s)
        --- FAIL: TestAccAWSAppmesh/VirtualService/virtualRouter (5.72s)
        --- PASS: TestAccAWSAppmesh/VirtualService/tags (18.31s)
```