### PR TITLE
command/results pr: update branch_name pattern to use the refs prefix

### DIFF
--- a/cmd/tctest/cli/tc.go
+++ b/cmd/tctest/cli/tc.go
@@ -157,7 +157,7 @@ func (tc TeamCity) TestResultsCmd(buildId string, wait bool) error {
 }
 
 func (tc TeamCity) TestResultsByPRCmd(pr, buildTypeId string, latest, wait bool) error {
-	locatorParams := fmt.Sprintf("buildType:%s,branch:name:/pull/%s/merge,running:any", buildTypeId, pr)
+	locatorParams := fmt.Sprintf("buildType:%s,branch:name:refs/pull/%s/merge,running:any", buildTypeId, pr)
 	if latest {
 		locatorParams += ",count:1"
 	}


### PR DESCRIPTION
Closes #35 

* Update branch:name filter from `/pull/%s/merge` to `refs/pull/%s/merge` to match the branch path used at build-time