### PR TITLE
fix tc token naming

### DIFF
--- a/cmd/tctest/cli/tc.go
+++ b/cmd/tctest/cli/tc.go
@@ -38,7 +38,7 @@ type TCBuild struct {
 
 func NewTeamCityFromViper() TeamCity {
 	server := viper.GetString("server")
-	token := viper.GetString("token")
+	token := viper.GetString("token-tc")
 	password := viper.GetString("password")
 	username := viper.GetString("username")
 	return NewTeamCity(server, token, username, password)


### PR DESCRIPTION
This change: 

https://github.com/katbyte/tctest/commit/78f9a4ad4a71f260c71eac5224b38dc8671087c1#diff-2139bb12ba26364d749591361faa60cfL263 

Changes the token key supplied for teamcity to change to `token-tc`, however it was not changed to match in `tc.go`. This PR makes that simple fix and lets TC Token Auth work as expected.