### PR TITLE
Removes default of "t" for TeamCity token

### DIFF
--- a/cmd/tctest/cli/cmds.go
+++ b/cmd/tctest/cli/cmds.go
@@ -226,7 +226,7 @@ Complete documentation is available at https://github.com/katbyte/tctest`,
 	pflags := root.PersistentFlags()
 	pflags.StringVarP(&flags.TC.ServerURL, "server", "s", "", "the TeamCity server's url")
 	pflags.StringVarP(&flags.TC.BuildTypeID, "buildtypeid", "b", "", "the TeamCity BuildTypeId to trigger")
-	pflags.StringVarP(&flags.TC.Token, "token-tc", "t", "t", "the TeamCity token to use (consider exporting token to TCTEST_TOKEN_TC instead)")
+	pflags.StringVarP(&flags.TC.Token, "token-tc", "t", "", "the TeamCity token to use (consider exporting token to TCTEST_TOKEN_TC instead)")
 	pflags.StringVarP(&flags.TC.User, "username", "u", "", "the TeamCity user to use")
 	pflags.StringVarP(&flags.TC.Pass, "password", "p", "", "the TeamCity password to use (consider exporting pass to TCTEST_PASS instead)")
 	pflags.StringVarP(&flags.TC.Parameters, "properties", "", "", "the TeamCity build parameters to use in 'KEY1=VALUE1;KEY2=VALUE2' format")

--- a/common/http.go
+++ b/common/http.go
@@ -56,6 +56,7 @@ func prettyPrintJsonLines(b []byte) string {
 	for i, p := range parts {
 		if b := []byte(p); json.Valid(b) {
 			var out bytes.Buffer
+			// nolint:errcheck
 			json.Indent(&out, b, "", " ")
 			parts[i] = out.String()
 		}


### PR DESCRIPTION
The TeamCity token was configured to have a default value of `"t"`, which forced token authentication with an invalid token.

Fixes #44 