### PR TITLE
Add flag to skip the build queue

### DIFF
--- a/cmd/tctest/cli/cmds.go
+++ b/cmd/tctest/cli/cmds.go
@@ -42,7 +42,7 @@ type FlagData struct {
 	Wait                WaitFlags
 	ServicePackagesMode bool
 	AllTests            bool
-	SkipQueue			bool
+	SkipQueue           bool
 }
 
 func ValidateParams(params []string) func(cmd *cobra.Command, args []string) error {

--- a/cmd/tctest/cli/cmds.go
+++ b/cmd/tctest/cli/cmds.go
@@ -297,7 +297,7 @@ Complete documentation is available at https://github.com/katbyte/tctest`,
 		"queue-timeout": "",
 		"run-timeout":   "",
 		"latest":        "TCTEST_LATESTBUILD",
-		"skip-queue":  "",
+		"skip-queue":    "TCTEST_SKIP_QUEUE",
 	}
 
 	for name, env := range m {

--- a/cmd/tctest/cli/cmds.go
+++ b/cmd/tctest/cli/cmds.go
@@ -36,12 +36,17 @@ type WaitFlags struct {
 	RunTimeout   int
 }
 
+//type TriggerFlags struct {
+//	QueueAtTop bool
+//}
+
 type FlagData struct {
 	TC                  TCFlags
 	PR                  PRFlags
 	Wait                WaitFlags
 	ServicePackagesMode bool
 	AllTests            bool
+	SkipQueue			bool
 }
 
 func ValidateParams(params []string) func(cmd *cobra.Command, args []string) error {
@@ -105,8 +110,9 @@ Complete documentation is available at https://github.com/katbyte/tctest`,
 			buildTypeId := viper.GetString("buildtypeid")
 			properties := viper.GetString("properties")
 			wait := viper.GetBool("wait")
+			skipQueue := viper.GetBool("skip-queue")
 
-			return NewTeamCityFromViper().BuildCmd(buildTypeId, properties, branch, "", testRegEx, wait)
+			return NewTeamCityFromViper().BuildCmd(buildTypeId, properties, branch, "", testRegEx, wait, skipQueue)
 		},
 	}
 	root.AddCommand(branch)
@@ -179,8 +185,9 @@ Complete documentation is available at https://github.com/katbyte/tctest`,
 					branch := fmt.Sprintf("refs/pull/%s/merge", pr)
 					properties := viper.GetString("properties")
 					wait := viper.GetBool("wait")
+					skipQueue := viper.GetBool("skip-queue")
 
-					if err := NewTeamCityFromViper().BuildCmd(buildTypeId, properties, branch, testRegEx, serviceInfo, wait); err != nil {
+					if err := NewTeamCityFromViper().BuildCmd(buildTypeId, properties, branch, testRegEx, serviceInfo, wait, skipQueue); err != nil {
 						return err
 					}
 					fmt.Println()
@@ -275,6 +282,8 @@ Complete documentation is available at https://github.com/katbyte/tctest`,
 	pflags.IntVarP(&flags.Wait.QueueTimeout, "queue-timeout", "", 60, "How long to wait for a queued build to start running before tctest times out")
 	pflags.IntVarP(&flags.Wait.RunTimeout, "run-timeout", "", 60, "How long to wait for a running build to finish before tctest times out")
 
+	pflags.BoolVarP(&flags.SkipQueue, "skip-queue", "", false, "Put the build to the queue top")
+
 	// binding map for viper/pflag -> env
 	m := map[string]string{
 		"server":        "TCTEST_SERVER",
@@ -292,6 +301,7 @@ Complete documentation is available at https://github.com/katbyte/tctest`,
 		"queue-timeout": "",
 		"run-timeout":   "",
 		"latest":        "TCTEST_LATESTBUILD",
+		"skip-queue":  "",
 	}
 
 	for name, env := range m {

--- a/cmd/tctest/cli/cmds.go
+++ b/cmd/tctest/cli/cmds.go
@@ -36,10 +36,6 @@ type WaitFlags struct {
 	RunTimeout   int
 }
 
-//type TriggerFlags struct {
-//	QueueAtTop bool
-//}
-
 type FlagData struct {
 	TC                  TCFlags
 	PR                  PRFlags

--- a/cmd/tctest/cli/pr.go
+++ b/cmd/tctest/cli/pr.go
@@ -18,22 +18,25 @@ func (gr GithubRepo) PrUrl(pr int) string {
 	return "https://github.com/" + gr.Owner + "/" + gr.Repo + "/pull/" + strconv.Itoa(pr)
 }
 
-func (gr GithubRepo) PrCmd(pr int, fileRegExStr, splitTestsAt string, servicePackagesMode bool) (*[]string, *[]string, error) {
+func (gr GithubRepo) PrCmd(pr int, fileRegExStr, splitTestsAt string) (*map[string][]string, error) {
 	c.Printf("Discovering tests for pr <cyan>#%d</> <darkGray>(%s)...</>\n", pr, gr.PrUrl(pr))
-	tests, services, err := gr.PrTests(pr, fileRegExStr, splitTestsAt, servicePackagesMode)
+	serviceTests, err := gr.PrTests(pr, fileRegExStr, splitTestsAt)
 	if err != nil {
-		return nil, nil, fmt.Errorf("pr list failed: %v", err)
+		return nil, fmt.Errorf("pr list failed: %v", err)
 	}
 
-	for _, t := range *tests {
-		fmt.Printf("    %s\n", t)
+	for service, tests := range *serviceTests {
+		c.Printf("    <yellow>%s</>:\n", service)
+		for _, t := range tests {
+			c.Printf("      %s\n", t)
+		}
 	}
 
-	return tests, services, nil
+	return serviceTests, nil
 }
 
 // todo break this apart - get/check PR state, get files, filter/process files, get tests, get services.
-func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string, servicePackagesMode bool) (*[]string, *[]string, error) {
+func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string) (*map[string][]string, error) {
 	client, ctx := gr.NewClient()
 	httpClient := common.NewHTTPClient("HTTP")
 	fileRegEx := regexp.MustCompile(filterRegExStr)
@@ -41,18 +44,18 @@ func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string, servi
 	common.Log.Debugf("fetching data for PR %s/%s/#%d...", gr.Owner, gr.Repo, pri)
 	pr, _, err := client.PullRequests.Get(ctx, gr.Owner, gr.Repo, pri)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	common.Log.Debugf("  checking pr state: %v", *pr.State)
 	if pr.State != nil && *pr.State == "closed" {
-		return nil, nil, fmt.Errorf("cannot start build for a closed pr")
+		return nil, fmt.Errorf("cannot start build for a closed pr")
 	}
 
 	common.Log.Tracef("listing files...")
 	files, _, err := client.PullRequests.ListFiles(ctx, gr.Owner, gr.Repo, pri, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// filter out uninteresting files and convert non test files to test files and only retain unique
@@ -66,6 +69,17 @@ func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string, servi
 		name := *f.Filename
 		common.Log.Debugf("    %v", *f.Filename)
 
+		// if in service package mode skip some files
+		if strings.Contains(name, "/services/") {
+			if strings.Contains(name, "/client/") || strings.Contains(name, "/parse/") || strings.Contains(name, "/validate/") {
+				continue
+			}
+
+			if strings.HasSuffix(name, "registration.go") || strings.HasSuffix(name, "resourceids.go") {
+				continue
+			}
+		}
+
 		if strings.HasSuffix(name, "_test.go") {
 			filesFiltered[name] = true
 			continue
@@ -76,24 +90,17 @@ func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string, servi
 		}
 
 		f := strings.Replace(name, ".go", "_test.go", 1)
-
-		if servicePackagesMode {
-			i := strings.LastIndex(f, "/")
-			filesFiltered[f[:i]+"/tests"+f[i:]] = true
-		} else {
-			filesFiltered[f] = true
-		}
+		filesFiltered[f] = true
 	}
 	common.Log.Debugf("  FOUND %d", len(filesFiltered))
 
 	if len(filesFiltered) == 0 {
-		return nil, nil, fmt.Errorf("found no files matching: %s", filterRegExStr)
+		return nil, fmt.Errorf("found no files matching: %s", filterRegExStr)
 	}
 	// log.Println(files) TODO debug message here
 
 	// for each file get content and parse out test files & services
-	testsm := map[string]bool{}
-	servicesm := map[string]bool{}
+	serviceTestMap := map[string]map[string]bool{}
 	common.Log.Debugf("  parsing content:")
 	for f := range filesFiltered {
 		testRegEx := regexp.MustCompile("func Test")
@@ -104,22 +111,23 @@ func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string, servi
 		// which has a 1000 file limit.
 		fileContents, _, _, err := client.Repositories.GetContents(ctx, gr.Owner, gr.Repo, f, &github.RepositoryContentGetOptions{Ref: *pr.MergeCommitSHA})
 		if err != nil {
-			return nil, nil, fmt.Errorf("downloading file (%s) metadata: %s", f, err)
+			c.Printf("    <darkGray>FAILED to download %s</>\n", f)
+			continue
 		}
 
 		if fileContents == nil {
-			return nil, nil, fmt.Errorf("downloading file (%s) metadata: no contents", f)
+			return nil, fmt.Errorf("downloading file (%s): no contents", f)
 		}
 
 		// GetContents has a 1MB limit. Use the DownloadURL to ensure we get full contents.
 		if fileContents.DownloadURL == nil || *fileContents.DownloadURL == "" {
-			return nil, nil, fmt.Errorf("downloading file (%s) metadata: missing DownloadURL", f)
+			return nil, fmt.Errorf("downloading file (%s): missing DownloadURL", f)
 		}
 
 		resp, err := httpClient.Get(*fileContents.DownloadURL)
 
 		if err != nil {
-			return nil, nil, fmt.Errorf("downloading file (%s): %s", f, err)
+			return nil, fmt.Errorf("downloading file (%s): %s", f, err)
 		}
 
 		defer resp.Body.Close()
@@ -131,7 +139,7 @@ func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string, servi
 
 			if testRegEx.MatchString(l) {
 				common.Log.Tracef("found test line: %s", l)
-				tests = append(tests, strings.Split(l, " ")[1]) //should always be true because test pattern is "func Test"
+				tests = append(tests, strings.Split(l, " ")[1]) // should always be true because test pattern is "func Test"
 			}
 		}
 
@@ -139,31 +147,36 @@ func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string, servi
 			fmt.Printf("pr file scanner error occurred: %s", err)
 		}
 
+		service := ""
+		parts := strings.Split(f, "/services/")
+		if len(parts) == 2 {
+			service = strings.Split(parts[1], "/")[0]
+		}
+
 		for _, t := range tests {
 			common.Log.Debugf("test: %s", t)
-			// if there is nothing split on `(` to make sure we just get the full function name
-			testsm[strings.Split(strings.Split(t, splitTestsAt)[0], "(")[0]] = true
-		}
 
-		if servicePackagesMode {
-			parts := strings.Split(f, "/services/")
-			if len(parts) == 2 {
-				servicesm[strings.Split(parts[1], "/")[0]] = true
+			if _, ok := serviceTestMap[service]; !ok {
+				serviceTestMap[service] = make(map[string]bool)
 			}
+
+			// if there is nothing split on `(` to make sure we just get the full function name
+			serviceTestMap[service][strings.Split(strings.Split(t, splitTestsAt)[0], "(")[0]] = true
 		}
 	}
 
-	tests := []string{}
-	for k := range testsm {
-		common.Log.Debugf("test prefix: %s", k)
-		tests = append(tests, k)
+	serviceTests := map[string][]string{}
+	for service := range serviceTestMap {
+		serviceTests[service] = []string{}
+		for test := range serviceTestMap[service] {
+			serviceInfo := ""
+			if service != "" {
+				serviceInfo = fmt.Sprintf("%s: ", service)
+			}
+			common.Log.Debugf("%s%s", serviceInfo, test)
+			serviceTests[service] = append(serviceTests[service], test)
+		}
 	}
 
-	services := []string{}
-	for k := range servicesm {
-		common.Log.Debugf("service: %s", k)
-		services = append(services, k)
-	}
-
-	return &tests, &services, nil
+	return &serviceTests, nil
 }

--- a/cmd/tctest/cli/tc.go
+++ b/cmd/tctest/cli/tc.go
@@ -298,6 +298,7 @@ func (tc TeamCity) triggerBuild(buildTypeId, branch string, testPattern, buildPr
 	// should be safe to send both
 	body := fmt.Sprintf(`
 <build>
+	<triggeringOptions queueAtTop="true"/>
 	<buildType id="%[1]s"/>
 	<properties>
         <property name="teamcity.build.branch" value="%[2]s"/>

--- a/cmd/tctest/cli/tc.go
+++ b/cmd/tctest/cli/tc.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -72,10 +73,10 @@ func NewTeamCityUsingBasicAuth(server, username, password string) TeamCity {
 	}
 }
 
-func (tc TeamCity) BuildCmd(buildTypeId, buildProperties, branch, testRegex, serviceInfo string, wait bool) error {
+func (tc TeamCity) BuildCmd(buildTypeId, buildProperties, branch, testRegex, serviceInfo string, wait bool, skipQueue bool) error {
 	c.Printf("triggering <magenta>%s</>%s @ <darkGray>%s...</>\n", branch, serviceInfo, buildTypeId)
 
-	buildId, buildUrl, err := tc.runBuild(buildTypeId, buildProperties, branch, testRegex)
+	buildId, buildUrl, err := tc.runBuild(buildTypeId, buildProperties, branch, testRegex, skipQueue)
 	if err != nil {
 		return fmt.Errorf("unable to trigger build: %v", err)
 	}
@@ -97,9 +98,9 @@ func (tc TeamCity) BuildCmd(buildTypeId, buildProperties, branch, testRegex, ser
 	return nil
 }
 
-func (tc TeamCity) runBuild(buildTypeId, buildProperties, branch string, testRegEx string) (string, string, error) {
+func (tc TeamCity) runBuild(buildTypeId, buildProperties, branch string, testRegEx string, skipQueue bool) (string, string, error) {
 	common.Log.Debugf("triggering build for %q", buildTypeId)
-	statusCode, body, err := tc.triggerBuild(buildTypeId, branch, testRegEx, buildProperties)
+	statusCode, body, err := tc.triggerBuild(buildTypeId, branch, testRegEx, buildProperties, skipQueue)
 	if err != nil {
 		return "", "", fmt.Errorf("error creating build request: %v", err)
 	}
@@ -277,7 +278,7 @@ func (tc TeamCity) waitForBuild(buildID string) error {
 	}
 }
 
-func (tc TeamCity) triggerBuild(buildTypeId, branch string, testPattern, buildProperties string) (int, string, error) {
+func (tc TeamCity) triggerBuild(buildTypeId, branch string, testPattern, buildProperties string, skipQueue bool) (int, string, error) {
 	bodyAdditionalProperties := ""
 
 	if buildProperties != "" {
@@ -298,7 +299,7 @@ func (tc TeamCity) triggerBuild(buildTypeId, branch string, testPattern, buildPr
 	// should be safe to send both
 	body := fmt.Sprintf(`
 <build>
-	<triggeringOptions queueAtTop="true"/>
+	<triggeringOptions queueAtTop="%[5]s"/>
 	<buildType id="%[1]s"/>
 	<properties>
         <property name="teamcity.build.branch" value="%[2]s"/>
@@ -307,7 +308,7 @@ func (tc TeamCity) triggerBuild(buildTypeId, branch string, testPattern, buildPr
         <property name="TEST_PREFIX" value="%[3]s"/>
 %[4]s	</properties>
 </build>
-`, buildTypeId, branch, testPattern, bodyAdditionalProperties)
+`, buildTypeId, branch, testPattern, bodyAdditionalProperties, strconv.FormatBool(skipQueue))
 
 	return tc.makePostRequest("/app/rest/2018.1/buildQueue", body)
 }


### PR DESCRIPTION
The build queues and wait times until the build starts in TeamCity have been long as of late. This flag will allow us to put builds triggered by tctest at the top of the queue.