### PR TITLE
Pass skip queue arg to BuildCmd in branch cmd

### DIFF
--- a/cmd/tctest/cli/cmds.go
+++ b/cmd/tctest/cli/cmds.go
@@ -108,7 +108,7 @@ Complete documentation is available at https://github.com/katbyte/tctest`,
 			wait := viper.GetBool("wait")
 			skipQueue := viper.GetBool("skip-queue")
 
-			return NewTeamCityFromViper().BuildCmd(buildTypeId, properties, branch, testRegEx, "", wait)
+			return NewTeamCityFromViper().BuildCmd(buildTypeId, properties, branch, testRegEx, "", wait, skipQueue)
 		},
 	}
 	root.AddCommand(branch)


### PR DESCRIPTION
Looks like I forgot to pass the skipQueue flag through to the BuildCmd call in the branch cmd.