### PR TITLE
update default file regex

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -62,7 +62,7 @@ func configureFlags(root *cobra.Command) error {
 
 	pflags.StringVar(&flags.GH.Token, "token-gh", "", "github oauth token (consider exporting token to GITHUB_TOKEN instead)")
 	pflags.StringVarP(&flags.GH.Repo, "repo", "r", "", "repository the pr resides in, such as terraform-providers/terraform-provider-azurerm")
-	pflags.StringVar(&flags.GH.FileRegEx, "fileregex", "(/[a-z_]*_resource|/[a-z_]*_data_source)", "the regex to filter files by`")
+	pflags.StringVar(&flags.GH.FileRegEx, "fileregex", "(/[a-z0-9_]*_resource|/[a-z0-9_]*_data_source)", "the regex to filter files by`")
 	pflags.StringVar(&flags.GH.SplitTestsOn, "splitteston", "_", "the character to split tests on and use the value on the left")
 
 	pflags.StringSliceVarP(&flags.GH.FilterPRs.Authors, "f-authors", "a", []string{}, "only test PR by these authors. ie 'katbyte,author2,author3'")

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -62,7 +62,7 @@ func configureFlags(root *cobra.Command) error {
 
 	pflags.StringVar(&flags.GH.Token, "token-gh", "", "github oauth token (consider exporting token to GITHUB_TOKEN instead)")
 	pflags.StringVarP(&flags.GH.Repo, "repo", "r", "", "repository the pr resides in, such as terraform-providers/terraform-provider-azurerm")
-	pflags.StringVar(&flags.GH.FileRegEx, "fileregex", "(/[a-z0-9_]*_resource|/[a-z0-9_]*_data_source)", "the regex to filter files by`")
+	pflags.StringVar(&flags.GH.FileRegEx, "fileregex", "(/[a-z0-9_]*_resource|/[a-z0-9_]*_data_source)|/[a-z0-9_]*_ephemeral", "the regex to filter files by`")
 	pflags.StringVar(&flags.GH.SplitTestsOn, "splitteston", "_", "the character to split tests on and use the value on the left")
 
 	pflags.StringSliceVarP(&flags.GH.FilterPRs.Authors, "f-authors", "a", []string{}, "only test PR by these authors. ie 'katbyte,author2,author3'")

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -62,7 +62,7 @@ func configureFlags(root *cobra.Command) error {
 
 	pflags.StringVar(&flags.GH.Token, "token-gh", "", "github oauth token (consider exporting token to GITHUB_TOKEN instead)")
 	pflags.StringVarP(&flags.GH.Repo, "repo", "r", "", "repository the pr resides in, such as terraform-providers/terraform-provider-azurerm")
-	pflags.StringVar(&flags.GH.FileRegEx, "fileregex", "(^[a-z]*/resource_|^[a-z]*/data_source_)", "the regex to filter files by`")
+	pflags.StringVar(&flags.GH.FileRegEx, "fileregex", "(/[a-z_]*_resource|/[a-z_]*_data_source)", "the regex to filter files by`")
 	pflags.StringVar(&flags.GH.SplitTestsOn, "splitteston", "_", "the character to split tests on and use the value on the left")
 
 	pflags.StringSliceVarP(&flags.GH.FilterPRs.Authors, "f-authors", "a", []string{}, "only test PR by these authors. ie 'katbyte,author2,author3'")


### PR DESCRIPTION
The current default value for `fileregex` seems outdated. this PR is to update it to filter all resource and data source files.

The current `list` command only output part of results:

```
~/a/a/i/s/keyvault ❯❯❯ tctest list 32257 
Discovering tests for pr #32257 
  https://github.com/terraform-providers/terraform-provider-azurerm/pull/32257
  keyvault:
    TestAccKeyVaultSecret
```

with this PR, it will output the full list:

```
~/a/tctest ❯❯❯ ./tctest list 32257
Discovering tests for pr #32257 
  https://github.com/terraform-providers/terraform-provider-azurerm/pull/32257
  keyvault:
    TestAccDataSourceKeyVaultSecret
    TestAccEphemeralKeyVaultSecret
    TestAccKeyVaultSecret
    TestAccDataSourceKeyVaultSecrets
    TestAccKeyVaultManagedStorageAccount```
