### PR TITLE
Flags: add a new flag to reappend the split character

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,28 +22,29 @@ All options can be passed as command-line flags but most can also be set via env
 
 ### Environment Variables
 
-| Variable | Flag | Description |
-|---|---|---|
-| `TCTEST_SERVER` | `--server`, `-s` | TeamCity server URL |
-| `TCTEST_BUILDTYPEID` | `--buildtypeid`, `-b` | TeamCity build configuration ID |
-| `TCTEST_TOKEN_TC` | `--token-tc`, `-t` | TeamCity authentication token |
-| `TCTEST_USER` | `--username` | TeamCity username (alternative to token) |
-| `TCTEST_PASS` | `--password` | TeamCity password (alternative to token) |
-| `TCTEST_PROPERTIES` | `--properties`, `-p` | Default build parameters in `KEY=VALUE;KEY2=VALUE2` format |
-| `GITHUB_TOKEN` | `--token-gh` | GitHub OAuth token |
-| `TCTEST_REPO` | `--repo`, `-r` | GitHub repository (e.g. `hashicorp/terraform-provider-azurerm`) |
-| `TCTEST_FILEREGEX` | `--fileregex` | Regex to filter PR files for test discovery |
-| `TCTEST_SPLIT_TESTS_ON` | `--splitteston` | Character to split test names on (default: `_`) |
-| `TCTEST_WAIT` | `--wait`, `-w` | Wait for builds to complete |
-| `TCTEST_LATESTBUILD` | `--latest` | Get the latest build |
-| `TCTEST_SKIP_QUEUE` | `--skip-queue`, `-q` | Put the build to the top of the queue |
-| `TCTEST_OPEN_BROWSER` | `--open`, `-o` | Open PR and build URLs in the browser |
-| `TCTEST_BUILD_TAGS` | `--tag` | Build tags to add to triggered builds |
-| `TCTEST_COMMENT` | `--comment`, `-c` | Post a GitHub comment with test results |
-| `TCTEST_FORCE_OLD_UI` | `--build-link-force-old-ui` | Force build URLs to use the classic TeamCity UI |
-| `TCTEST_OUTPUT_QUIET` | `--quiet` | Minimal machine-readable output |
-| `TCTEST_OUTPUT_JSON` | `--json` | Output build results as a JSON array |
-| `TCTEST_OUTPUT_SILENT` | `--silent` | Suppress all output |
+| Variable                          | Flag | Description                                                                                   |
+|-----------------------------------|---|-----------------------------------------------------------------------------------------------|
+| `TCTEST_SERVER`                   | `--server`, `-s` | TeamCity server URL                                                                           |
+| `TCTEST_BUILDTYPEID`              | `--buildtypeid`, `-b` | TeamCity build configuration ID                                                               |
+| `TCTEST_TOKEN_TC`                 | `--token-tc`, `-t` | TeamCity authentication token                                                                 |
+| `TCTEST_USER`                     | `--username` | TeamCity username (alternative to token)                                                      |
+| `TCTEST_PASS`                     | `--password` | TeamCity password (alternative to token)                                                      |
+| `TCTEST_PROPERTIES`               | `--properties`, `-p` | Default build parameters in `KEY=VALUE;KEY2=VALUE2` format                                    |
+| `GITHUB_TOKEN`                    | `--token-gh` | GitHub OAuth token                                                                            |
+| `TCTEST_REPO`                     | `--repo`, `-r` | GitHub repository (e.g. `hashicorp/terraform-provider-azurerm`)                               |
+| `TCTEST_FILEREGEX`                | `--fileregex` | Regex to filter PR files for test discovery                                                   |
+| `TCTEST_SPLIT_TESTS_ON`           | `--splitteston` | Character to split test names on (default: `_`)                                               |
+| `TCTEST_REAPPEND_SPLIT_CHARACTER` | `--reappend-split-character` | Whether to append the split character to the resulting test filter for more precise filtering |
+| `TCTEST_WAIT`                     | `--wait`, `-w` | Wait for builds to complete                                                                   |
+| `TCTEST_LATESTBUILD`              | `--latest` | Get the latest build                                                                          |
+| `TCTEST_SKIP_QUEUE`               | `--skip-queue`, `-q` | Put the build to the top of the queue                                                         |
+| `TCTEST_OPEN_BROWSER`             | `--open`, `-o` | Open PR and build URLs in the browser                                                         |
+| `TCTEST_BUILD_TAGS`               | `--tag` | Build tags to add to triggered builds                                                         |
+| `TCTEST_COMMENT`                  | `--comment`, `-c` | Post a GitHub comment with test results                                                       |
+| `TCTEST_FORCE_OLD_UI`             | `--build-link-force-old-ui` | Force build URLs to use the classic TeamCity UI                                               |
+| `TCTEST_OUTPUT_QUIET`             | `--quiet` | Minimal machine-readable output                                                               |
+| `TCTEST_OUTPUT_JSON`              | `--json` | Output build results as a JSON array                                                          |
+| `TCTEST_OUTPUT_SILENT`            | `--silent` | Suppress all output                                                                           |
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -22,29 +22,29 @@ All options can be passed as command-line flags but most can also be set via env
 
 ### Environment Variables
 
-| Variable                          | Flag | Description                                                                                   |
-|-----------------------------------|---|-----------------------------------------------------------------------------------------------|
-| `TCTEST_SERVER`                   | `--server`, `-s` | TeamCity server URL                                                                           |
-| `TCTEST_BUILDTYPEID`              | `--buildtypeid`, `-b` | TeamCity build configuration ID                                                               |
-| `TCTEST_TOKEN_TC`                 | `--token-tc`, `-t` | TeamCity authentication token                                                                 |
-| `TCTEST_USER`                     | `--username` | TeamCity username (alternative to token)                                                      |
-| `TCTEST_PASS`                     | `--password` | TeamCity password (alternative to token)                                                      |
-| `TCTEST_PROPERTIES`               | `--properties`, `-p` | Default build parameters in `KEY=VALUE;KEY2=VALUE2` format                                    |
-| `GITHUB_TOKEN`                    | `--token-gh` | GitHub OAuth token                                                                            |
-| `TCTEST_REPO`                     | `--repo`, `-r` | GitHub repository (e.g. `hashicorp/terraform-provider-azurerm`)                               |
-| `TCTEST_FILEREGEX`                | `--fileregex` | Regex to filter PR files for test discovery                                                   |
-| `TCTEST_SPLIT_TESTS_ON`           | `--splitteston` | Character to split test names on (default: `_`)                                               |
+| Variable | Flag | Description |
+|---|---|---|
+| `TCTEST_SERVER` | `--server`, `-s` | TeamCity server URL |
+| `TCTEST_BUILDTYPEID` | `--buildtypeid`, `-b` | TeamCity build configuration ID |
+| `TCTEST_TOKEN_TC` | `--token-tc`, `-t` | TeamCity authentication token |
+| `TCTEST_USER` | `--username` | TeamCity username (alternative to token) |
+| `TCTEST_PASS` | `--password` | TeamCity password (alternative to token) |
+| `TCTEST_PROPERTIES` | `--properties`, `-p` | Default build parameters in `KEY=VALUE;KEY2=VALUE2` format |
+| `GITHUB_TOKEN` | `--token-gh` | GitHub OAuth token |
+| `TCTEST_REPO` | `--repo`, `-r` | GitHub repository (e.g. `hashicorp/terraform-provider-azurerm`) |
+| `TCTEST_FILEREGEX` | `--fileregex` | Regex to filter PR files for test discovery |
+| `TCTEST_SPLIT_TESTS_ON` | `--splitteston` | Character to split test names on (default: `_`) |
 | `TCTEST_REAPPEND_SPLIT_CHARACTER` | `--reappend-split-character` | Whether to append the split character to the resulting test filter for more precise filtering |
-| `TCTEST_WAIT`                     | `--wait`, `-w` | Wait for builds to complete                                                                   |
-| `TCTEST_LATESTBUILD`              | `--latest` | Get the latest build                                                                          |
-| `TCTEST_SKIP_QUEUE`               | `--skip-queue`, `-q` | Put the build to the top of the queue                                                         |
-| `TCTEST_OPEN_BROWSER`             | `--open`, `-o` | Open PR and build URLs in the browser                                                         |
-| `TCTEST_BUILD_TAGS`               | `--tag` | Build tags to add to triggered builds                                                         |
-| `TCTEST_COMMENT`                  | `--comment`, `-c` | Post a GitHub comment with test results                                                       |
-| `TCTEST_FORCE_OLD_UI`             | `--build-link-force-old-ui` | Force build URLs to use the classic TeamCity UI                                               |
-| `TCTEST_OUTPUT_QUIET`             | `--quiet` | Minimal machine-readable output                                                               |
-| `TCTEST_OUTPUT_JSON`              | `--json` | Output build results as a JSON array                                                          |
-| `TCTEST_OUTPUT_SILENT`            | `--silent` | Suppress all output                                                                           |
+| `TCTEST_WAIT` | `--wait`, `-w` | Wait for builds to complete |
+| `TCTEST_LATESTBUILD` | `--latest` | Get the latest build |
+| `TCTEST_SKIP_QUEUE` | `--skip-queue`, `-q` | Put the build to the top of the queue |
+| `TCTEST_OPEN_BROWSER` | `--open`, `-o` | Open PR and build URLs in the browser |
+| `TCTEST_BUILD_TAGS` | `--tag` | Build tags to add to triggered builds |
+| `TCTEST_COMMENT` | `--comment`, `-c` | Post a GitHub comment with test results |
+| `TCTEST_FORCE_OLD_UI` | `--build-link-force-old-ui` | Force build URLs to use the classic TeamCity UI |
+| `TCTEST_OUTPUT_QUIET` | `--quiet` | Minimal machine-readable output |
+| `TCTEST_OUTPUT_JSON` | `--json` | Output build results as a JSON array |
+| `TCTEST_OUTPUT_SILENT` | `--silent` | Suppress all output |
 
 ## Commands
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -58,11 +58,12 @@ type FlagData struct {
 }
 
 type FlagsGitHub struct {
-	Token        string
-	Repo         string
-	FileRegEx    string
-	SplitTestsOn string
-	FilterPRs    FlagsGitHubPrFilter
+	Token                  string
+	Repo                   string
+	FileRegEx              string
+	SplitTestsOn           string
+	ReappendSplitCharacter bool
+	FilterPRs              FlagsGitHubPrFilter
 }
 
 type FlagsGitHubPrFilter struct {
@@ -114,6 +115,7 @@ func configureFlags(root *cobra.Command) error {
 	pflags.StringVarP(&flags.GH.Repo, "repo", "r", "", "repository the pr resides in, such as terraform-providers/terraform-provider-azurerm")
 	pflags.StringVar(&flags.GH.FileRegEx, "fileregex", "(/[a-z0-9_]*_resource|/[a-z0-9_]*_data_source)|/[a-z0-9_]*_ephemeral", "the regex to filter files by`")
 	pflags.StringVar(&flags.GH.SplitTestsOn, "splitteston", "_", "the character to split tests on and use the value on the left")
+	pflags.BoolVar(&flags.GH.ReappendSplitCharacter, "reappend-split-character", false, "whether to append the split character to the resulting test filter for more precise filtering")
 
 	pflags.StringSliceVarP(&flags.GH.FilterPRs.Authors, "f-authors", "a", []string{}, "only test PR by these authors. ie 'katbyte,author2,author3'")
 	pflags.StringSliceVarP(&flags.GH.FilterPRs.LabelsAnd, "f-labels-all", "l", []string{}, "only test PRs that match all label conditions. ie 'label1,label2,-not-this-label'")
@@ -155,6 +157,7 @@ func configureFlags(root *cobra.Command) error {
 		"repo":                             "TCTEST_REPO",
 		"fileregex":                        "TCTEST_FILEREGEX",
 		"splitteston":                      "TCTEST_SPLIT_TESTS_ON",
+		"reappend-split-character":         "TCTEST_REAPPEND_SPLIT_CHARACTER",
 		"wait":                             "TCTEST_WAIT",
 		"all":                              "",
 		"service":                          "",
@@ -214,10 +217,11 @@ func GetFlags() FlagData {
 		JSON:          viper.GetBool("json"),
 		Silent:        viper.GetBool("silent"),
 		GH: FlagsGitHub{
-			Repo:         viper.GetString("repo"),
-			Token:        viper.GetString("token-gh"),
-			FileRegEx:    viper.GetString("fileregex"),
-			SplitTestsOn: viper.GetString("splitteston"),
+			Repo:                   viper.GetString("repo"),
+			Token:                  viper.GetString("token-gh"),
+			FileRegEx:              viper.GetString("fileregex"),
+			SplitTestsOn:           viper.GetString("splitteston"),
+			ReappendSplitCharacter: viper.GetBool("reappend-split-character"),
 			FilterPRs: FlagsGitHubPrFilter{
 				Authors:      viper.GetStringSlice("f-authors"),
 				LabelsOr:     viper.GetStringSlice("f-labels-any"),

--- a/cli/gh-pr.go
+++ b/cli/gh-pr.go
@@ -150,7 +150,7 @@ func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string, reapp
 			testName := strings.Split(strings.Split(t, splitTestsAt)[0], "(")[0]
 
 			if reappendSplitChar && splitTestsAt != "" {
-				testName = testName + splitTestsAt
+				testName += splitTestsAt
 			}
 
 			serviceTestMap[service][testName] = true

--- a/cli/gh-pr.go
+++ b/cli/gh-pr.go
@@ -24,7 +24,7 @@ func (f FlagData) GetPrTests(number int, title string) (*map[string][]string, er
 
 	prURL := gr.PrURL(number)
 	cout.Printf("Discovering tests for pr <cyan>#%d</> %s <darkGray>%s</>\n", number, title, prURL)
-	serviceTests, err := gr.PrTests(number, f.GH.FileRegEx, f.GH.SplitTestsOn)
+	serviceTests, err := gr.PrTests(number, f.GH.FileRegEx, f.GH.SplitTestsOn, f.GH.ReappendSplitCharacter)
 
 	if f.OpenInBrowser {
 		if err := browser.OpenURL(prURL); err != nil {
@@ -47,7 +47,7 @@ func (f FlagData) GetPrTests(number int, title string) (*map[string][]string, er
 }
 
 // todo break this apart - get/check PR state, get files, filter/process files, get tests, get services.
-func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string) (*map[string][]string, error) {
+func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string, reappendSplitChar bool) (*map[string][]string, error) {
 	client, ctx := gr.NewClient()
 	httpClient := chttp.NewHTTPClient("HTTP")
 
@@ -147,7 +147,13 @@ func (gr GithubRepo) PrTests(pri int, filterRegExStr, splitTestsAt string) (*map
 			}
 
 			// if there is nothing split on `(` to make sure we just get the full function name
-			serviceTestMap[service][strings.Split(strings.Split(t, splitTestsAt)[0], "(")[0]] = true
+			testName := strings.Split(strings.Split(t, splitTestsAt)[0], "(")[0]
+
+			if reappendSplitChar && splitTestsAt != "" {
+				testName = testName + splitTestsAt
+			}
+
+			serviceTestMap[service][testName] = true
 		}
 	}
 


### PR DESCRIPTION
Adds a flag to allow reappending the split character, e.g.

`TestAccVirtualNetwork_basic` split on `_`, results in a test filter of `TestAccVirtualNetwork`, which then also matches `TestAccVirtualNetworkGateway` (and others). By reappending the character the test name was split on it allows for more precise filtering and avoids running irrelevant tests