### PR TITLE
error on merge conflicts via mergeable check and fail when no builds are triggered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## v1.3.0 (unreleased)
 
 - `--wait` now errors when a build is cancelled (e.g. by TeamCity on a temporary VCS error) instead of treating it as a successful run with no results, and includes TeamCity's cancellation reason ([#31](https://github.com/katbyte/tctest/issues/31))
+- error clearly when a PR has merge conflicts: check the PR's `mergeable` state (retrying while GitHub computes it) instead of relying on `merge_commit_sha`, which GitHub keeps serving stale for PRs that become conflicted — previously builds were triggered on a stale or missing merge ref and failed invisibly inside TeamCity
+- exit non-zero with `no builds were triggered` when discovery finds nothing to run, so CI wrappers (e.g. the azurerm `/test` comment workflow) report it instead of treating a no-op run as success
+- the AST discovery path verifies mergeability via the API before fetching the merge ref, which could otherwise succeed on a stale ref
 
 ## v1.2.0 (2026-08-10)
 

--- a/cli/pr.go
+++ b/cli/pr.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/go-github/v89/github"
 	"github.com/katbyte/tctest/lib/chttp"
@@ -45,6 +46,11 @@ func (f *FlagData) GetPrTests(number int, title string) (map[string][]string, er
 		if repoPath != "" {
 			f.DiscoveryConfig.LocalRepoPath = repoPath
 			cout.Printf("Discovering tests for pr <cyan>#%d</> %s <darkGray>%s</> <yellow>[mode=AST]</>%s\n", number, title, prURL, cwdWarning)
+			// the AST path fetches refs/pull/N/merge via git, which can succeed on a
+			// stale merge ref for a conflicted PR — verify mergeability via the API first
+			if _, err := ghr.GetPrForBuild(number); err != nil {
+				return nil, err
+			}
 			serviceTests, err = ghr.PrTestsFromAst(number, f.DiscoveryConfig)
 		} else {
 			cout.Printf("Discovering tests for pr <cyan>#%d</> %s <darkGray>%s</> <yellow>[mode=api (fallback)]</>\n", number, title, prURL)
@@ -79,24 +85,65 @@ func (f *FlagData) GetPrTests(number int, title string) (map[string][]string, er
 	return serviceTests, nil
 }
 
+// mergeableAttempts and mergeableRetryDelay control how long GetPrForBuild waits for
+// GitHub to finish computing a PR's mergeability (the computation is asynchronous and
+// a GET on the PR is what kicks it off).
+const (
+	mergeableAttempts   = 5
+	mergeableRetryDelay = 3 * time.Second
+)
+
+// GetPrForBuild fetches a PR and verifies builds can be triggered on its merge ref: it
+// must be open, mergeable, and have a merge commit SHA. Mergeable has to be checked
+// explicitly — GitHub keeps returning a stale merge_commit_sha for a PR that has
+// *become* conflicted, so a nil-SHA check alone lets conflicted PRs through to trigger
+// builds on a stale or missing refs/pull/N/merge ref, which then fail (or silently test
+// outdated code) inside TeamCity where nobody sees it.
+func (ghr GithubRepo) GetPrForBuild(number int) (*github.PullRequest, error) {
+	client, ctx := ghr.NewClient()
+
+	for attempt := 1; ; attempt++ {
+		clog.Log.Debugf("fetching data for PR %s/%s/#%d...", ghr.Owner, ghr.Name, number)
+		pr, _, err := client.PullRequests.Get(ctx, ghr.Owner, ghr.Name, number)
+		if err != nil {
+			return nil, gh.WrapGitHubError(err, fmt.Sprintf("fetching PR %s/%s/#%d", ghr.Owner, ghr.Name, number))
+		}
+
+		clog.Log.Debugf("  checking pr state: %v", pr.GetState())
+		if pr.GetState() == gh.PRStateClosed {
+			return nil, errors.New("cannot start build for a closed pr")
+		}
+
+		if pr.Mergeable == nil {
+			if attempt < mergeableAttempts {
+				clog.Log.Debugf("  mergeability of PR #%d not yet computed by github, retrying (%d/%d)...", number, attempt, mergeableAttempts)
+				time.Sleep(mergeableRetryDelay)
+				continue
+			}
+			return nil, fmt.Errorf("github has not finished computing mergeability for PR #%d, try again shortly", number)
+		}
+
+		if !pr.GetMergeable() {
+			return nil, fmt.Errorf("PR #%d has merge conflicts that must be resolved before tests can be run", number)
+		}
+
+		if pr.MergeCommitSHA == nil {
+			return nil, fmt.Errorf("PR #%d is mergeable but github has no merge commit SHA for it yet, try again shortly", number)
+		}
+
+		return pr, nil
+	}
+}
+
 // PrTestsFromAPI fetches the list of files changed in a PR and determines which tests should be run.
 // It uses GetPullRequestTestFiles to get the files, groups them into packages, and returns a map of package names to a list of test names.
 func (ghr GithubRepo) PrTestsFromAPI(pri int, cfg DiscoveryConfig) (map[string][]string, error) {
-	client, ctx := ghr.NewClient()
+	_, ctx := ghr.NewClient()
 	httpClient := chttp.NewHTTPClient("HTTP")
 
-	clog.Log.Debugf("fetching data for PR %s/%s/#%d...", ghr.Owner, ghr.Name, pri)
-	pr, _, err := client.PullRequests.Get(ctx, ghr.Owner, ghr.Name, pri)
+	pr, err := ghr.GetPrForBuild(pri)
 	if err != nil {
-		return nil, gh.WrapGitHubError(err, fmt.Sprintf("fetching PR %s/%s/#%d", ghr.Owner, ghr.Name, pri))
-	}
-
-	clog.Log.Debugf("  checking pr state: %v", pr.GetState())
-	if pr.GetState() == gh.PRStateClosed {
-		return nil, errors.New("cannot start build for a closed pr")
-	}
-	if pr.MergeCommitSHA == nil {
-		return nil, errors.New("merge commit SHA is nil, is there a merge conflict?")
+		return nil, err
 	}
 
 	clog.Log.Tracef("listing files...")
@@ -190,24 +237,12 @@ func (ghr GithubRepo) PrTestsFromAPI(pri int, cfg DiscoveryConfig) (map[string][
 	return serviceTests, nil
 }
 
-// CheckPrCanBuild verifies a PR exists, is open, and has a merge commit. Used by the
+// CheckPrCanBuild verifies a PR exists, is open, and is mergeable. Used by the
 // direct-trigger path (--service + --all/test regex), which skips discovery and would
 // otherwise happily trigger builds on a stale or missing refs/pull/N/merge ref.
 func (f *FlagData) CheckPrCanBuild(number int) error {
-	ghr := f.NewRepo()
-	client, ctx := ghr.NewClient()
-
-	pr, _, err := client.PullRequests.Get(ctx, ghr.Owner, ghr.Name, number)
-	if err != nil {
-		return gh.WrapGitHubError(err, fmt.Sprintf("fetching PR %s/%s/#%d", ghr.Owner, ghr.Name, number))
-	}
-	if pr.GetState() == gh.PRStateClosed {
-		return errors.New("cannot start build for a closed pr")
-	}
-	if pr.MergeCommitSHA == nil {
-		return errors.New("merge commit SHA is nil, is there a merge conflict?")
-	}
-	return nil
+	_, err := f.NewRepo().GetPrForBuild(number)
+	return err
 }
 
 // GetPullRequestTestFiles fetches all changed files in a PR and determines the related test files.

--- a/cli/pr.go
+++ b/cli/pr.go
@@ -10,13 +10,11 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/google/go-github/v89/github"
 	"github.com/katbyte/tctest/lib/chttp"
 	"github.com/katbyte/tctest/lib/clog"
 	"github.com/katbyte/tctest/lib/cout"
-	"github.com/katbyte/tctest/lib/gh"
 	"github.com/katbyte/tctest/lib/git"
 	"github.com/katbyte/tctest/lib/provider"
 	"github.com/pkg/browser"
@@ -83,56 +81,6 @@ func (f *FlagData) GetPrTests(number int, title string) (map[string][]string, er
 	}
 
 	return serviceTests, nil
-}
-
-// mergeableAttempts and mergeableRetryDelay control how long GetPrForBuild waits for
-// GitHub to finish computing a PR's mergeability (the computation is asynchronous and
-// a GET on the PR is what kicks it off).
-const (
-	mergeableAttempts   = 5
-	mergeableRetryDelay = 3 * time.Second
-)
-
-// GetPrForBuild fetches a PR and verifies builds can be triggered on its merge ref: it
-// must be open, mergeable, and have a merge commit SHA. Mergeable has to be checked
-// explicitly — GitHub keeps returning a stale merge_commit_sha for a PR that has
-// *become* conflicted, so a nil-SHA check alone lets conflicted PRs through to trigger
-// builds on a stale or missing refs/pull/N/merge ref, which then fail (or silently test
-// outdated code) inside TeamCity where nobody sees it.
-func (ghr GithubRepo) GetPrForBuild(number int) (*github.PullRequest, error) {
-	client, ctx := ghr.NewClient()
-
-	for attempt := 1; ; attempt++ {
-		clog.Log.Debugf("fetching data for PR %s/%s/#%d...", ghr.Owner, ghr.Name, number)
-		pr, _, err := client.PullRequests.Get(ctx, ghr.Owner, ghr.Name, number)
-		if err != nil {
-			return nil, gh.WrapGitHubError(err, fmt.Sprintf("fetching PR %s/%s/#%d", ghr.Owner, ghr.Name, number))
-		}
-
-		clog.Log.Debugf("  checking pr state: %v", pr.GetState())
-		if pr.GetState() == gh.PRStateClosed {
-			return nil, errors.New("cannot start build for a closed pr")
-		}
-
-		if pr.Mergeable == nil {
-			if attempt < mergeableAttempts {
-				clog.Log.Debugf("  mergeability of PR #%d not yet computed by github, retrying (%d/%d)...", number, attempt, mergeableAttempts)
-				time.Sleep(mergeableRetryDelay)
-				continue
-			}
-			return nil, fmt.Errorf("github has not finished computing mergeability for PR #%d, try again shortly", number)
-		}
-
-		if !pr.GetMergeable() {
-			return nil, fmt.Errorf("PR #%d has merge conflicts that must be resolved before tests can be run", number)
-		}
-
-		if pr.MergeCommitSHA == nil {
-			return nil, fmt.Errorf("PR #%d is mergeable but github has no merge commit SHA for it yet, try again shortly", number)
-		}
-
-		return pr, nil
-	}
 }
 
 // PrTestsFromAPI fetches the list of files changed in a PR and determines which tests should be run.

--- a/cli/prs.go
+++ b/cli/prs.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -155,6 +156,12 @@ func (f *FlagData) GetAndRunPrsTests(prs map[int]string, testRegExParam string) 
 	}
 	if buildsFailed > 0 {
 		return fmt.Errorf("%d build(s) failed to trigger", buildsFailed)
+	}
+	// zero builds for one or more PRs is a failure, not a quiet no-op — wrappers like
+	// the /test comment workflow treat exit 0 as "builds are running", so exiting
+	// clean here would eat the "no tests found" errors printed above
+	if buildsTriggered == 0 && len(prNumbers) > 0 {
+		return errors.New("no builds were triggered")
 	}
 
 	return nil

--- a/integration/integration_aws_test.go
+++ b/integration/integration_aws_test.go
@@ -72,9 +72,10 @@ func TestAPIDiscoveryAWS(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		args []string
-		want []trigger
+		name     string
+		args     []string
+		want     []trigger
+		wantExit int
 	}{
 		{
 			name: "resource change derives plain and generated test files",
@@ -110,9 +111,10 @@ func TestAPIDiscoveryAWS(t *testing.T) {
 			},
 		},
 		{
-			name: "generated and export files only trigger nothing",
-			args: []string{"pr", "10006"},
-			want: nil,
+			name:     "generated and export files only trigger nothing and fail",
+			args:     []string{"pr", "10006"},
+			want:     nil,
+			wantExit: 1,
 		},
 		{
 			name: "plural data source derives only its own test",
@@ -124,9 +126,10 @@ func TestAPIDiscoveryAWS(t *testing.T) {
 			// service dir (stream_processor_migrate.go), the prefix match finds no
 			// sibling tests, so nothing runs even though stream_processor tests
 			// arguably should
-			name: "flat migrate helper alone triggers nothing",
-			args: []string{"pr", "10008"},
-			want: nil,
+			name:     "flat migrate helper alone triggers nothing and fails",
+			args:     []string{"pr", "10008"},
+			want:     nil,
+			wantExit: 1,
 		},
 		{
 			name: "--service filters a multi-service pr",
@@ -153,8 +156,8 @@ func TestAPIDiscoveryAWS(t *testing.T) {
 			tc := newMockTeamCity(t)
 
 			res := runTCTest(t, awsEnv(gh, tc), tt.args...)
-			if res.exitCode != 0 {
-				t.Fatalf("exit code = %d, want 0\noutput:\n%s", res.exitCode, res.output)
+			if res.exitCode != tt.wantExit {
+				t.Fatalf("exit code = %d, want %d\noutput:\n%s", res.exitCode, tt.wantExit, res.output)
 			}
 			assertTriggers(t, tc, res, tt.want)
 		})
@@ -168,9 +171,10 @@ func TestASTDiscoveryAWS(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		args []string
-		want []trigger
+		name     string
+		args     []string
+		want     []trigger
+		wantExit int
 	}{
 		{
 			name: "sdk resource without _resource suffix derives its test family",
@@ -194,9 +198,10 @@ func TestASTDiscoveryAWS(t *testing.T) {
 			// exports_test.go is classified as a unit test here because AST mode
 			// reads its content (no TestAcc funcs), unlike the API path's
 			// filename-based fallback
-			name: "generated and export files only trigger nothing",
-			args: []string{"pr", "20004"},
-			want: nil,
+			name:     "generated and export files only trigger nothing and fail",
+			args:     []string{"pr", "20004"},
+			want:     nil,
+			wantExit: 1,
 		},
 	}
 
@@ -212,8 +217,8 @@ func TestASTDiscoveryAWS(t *testing.T) {
 			env["TCTEST_LOCAL_REPO_PATH"] = clone
 
 			res := runTCTest(t, env, tt.args...)
-			if res.exitCode != 0 {
-				t.Fatalf("exit code = %d, want 0\noutput:\n%s", res.exitCode, res.output)
+			if res.exitCode != tt.wantExit {
+				t.Fatalf("exit code = %d, want %d\noutput:\n%s", res.exitCode, tt.wantExit, res.output)
 			}
 			if !strings.Contains(res.output, "[mode=AST]") {
 				t.Fatalf("expected AST discovery mode to be used\noutput:\n%s", res.output)

--- a/integration/integration_azurerm_test.go
+++ b/integration/integration_azurerm_test.go
@@ -37,6 +37,9 @@ var azurermPRs = []prDef{
 		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
 		{"internal/services/postgres/validate/database_charset.go", "modified"},
 	}},
+	{1009, "open", "conflicted pr", []changedFile{
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
+	}},
 	{1020, "open", "postgres improvement", []changedFile{
 		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
 	}},
@@ -84,7 +87,13 @@ var azurermASTPRs = []prDef{
 		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
 		{"internal/services/postgres/validate/database_charset.go", "modified"},
 	}},
+	{2012, "open", "conflicted pr", []changedFile{
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
+	}},
 }
+
+// conflictedPRs marks the PR numbers the mock serves with mergeable=false
+var conflictedPRs = map[int]bool{1009: true, 2012: true}
 
 func azurermEnv(gh *mockGitHub, tc *mockTeamCity) map[string]string {
 	return map[string]string{
@@ -119,9 +128,26 @@ func TestAPIDiscoveryAzureRM(t *testing.T) {
 			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/1002/merge", "(TestAccDataSourcePostgresqlflexibleServer|TestAccPostgresqlFlexibleServer)"}},
 		},
 		{
-			name: "helper-only change discovers nothing in API mode",
-			args: []string{"pr", "1003"},
-			want: nil,
+			// discovering nothing must exit non-zero so wrappers (the /test comment
+			// workflow) report it instead of reacting as if builds were triggered
+			name:     "helper-only change discovers nothing in API mode and fails",
+			args:     []string{"pr", "1003"},
+			want:     nil,
+			wantExit: 1,
+		},
+		{
+			name:     "conflicted pr errors and triggers nothing",
+			args:     []string{"pr", "1009"},
+			want:     nil,
+			wantExit: 1,
+		},
+		{
+			// the --service direct-trigger path skips discovery but must still
+			// refuse to trigger builds for a conflicted pr
+			name:     "conflicted pr errors on the --service direct path",
+			args:     []string{"pr", "1009", "--service", "postgres", "--all"},
+			want:     nil,
+			wantExit: 1,
 		},
 		{
 			name: "multi-service pr triggers one build per service",
@@ -209,6 +235,7 @@ func TestAPIDiscoveryAzureRM(t *testing.T) {
 			t.Parallel()
 			scenario(t, "api/azurerm", tt.name)
 			gh := newMockGitHub(t, "testdata/azurerm", azurermPRs)
+			gh.conflicted = conflictedPRs
 			tc := newMockTeamCity(t)
 
 			res := runTCTest(t, azurermEnv(gh, tc), tt.args...)
@@ -320,6 +347,14 @@ func TestASTDiscoveryAzureRM(t *testing.T) {
 			args: []string{"pr", "2011"},
 			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/2011/merge", "(TestAccDataSourcePostgresqlflexibleServer|TestAccPostgresqlFlexibleServer|TestAccPostgresqlFlexibleServerDatabase)"}},
 		},
+		{
+			// the mergeable check must run before the AST path fetches the merge
+			// ref, which can succeed on a stale ref for a conflicted pr
+			name:     "conflicted pr errors and triggers nothing",
+			args:     []string{"pr", "2012"},
+			want:     nil,
+			wantExit: 1,
+		},
 	}
 
 	for _, tt := range cases {
@@ -327,6 +362,7 @@ func TestASTDiscoveryAzureRM(t *testing.T) {
 			t.Parallel()
 			scenario(t, "ast/azurerm", tt.name)
 			gh := newMockGitHub(t, "testdata/azurerm", azurermASTPRs)
+			gh.conflicted = conflictedPRs
 			tc := newMockTeamCity(t)
 			clone := cloneUpstream(t, azurermUpstream)
 
@@ -342,6 +378,48 @@ func TestASTDiscoveryAzureRM(t *testing.T) {
 				t.Fatalf("expected AST discovery mode to be used\noutput:\n%s", res.output)
 			}
 			assertTriggers(t, tc, res, tt.want)
+		})
+	}
+}
+
+// TestErrorMessages locks the wording of the errors that comment workflows surface
+// on PRs — they must clearly say WHY nothing was triggered, not just fail.
+func TestErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "conflicted pr names the conflict",
+			args: []string{"pr", "1009"},
+			want: "has merge conflicts that must be resolved before tests can be run",
+		},
+		{
+			name: "no discovered tests reports no builds were triggered",
+			args: []string{"pr", "1003"},
+			want: "no builds were triggered",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			scenario(t, "errors/azurerm", tt.name)
+			gh := newMockGitHub(t, "testdata/azurerm", azurermPRs)
+			gh.conflicted = conflictedPRs
+			tc := newMockTeamCity(t)
+
+			res := runTCTest(t, azurermEnv(gh, tc), tt.args...)
+			if res.exitCode == 0 {
+				t.Fatalf("exit code = 0, want non-zero\noutput:\n%s", res.output)
+			}
+			if !strings.Contains(res.output, tt.want) {
+				t.Fatalf("output missing %q:\n%s", tt.want, res.output)
+			}
+			assertTriggers(t, tc, res, nil)
 		})
 	}
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -176,10 +176,11 @@ type listPR struct {
 }
 
 type mockGitHub struct {
-	srv     *httptest.Server
-	fixture string // fixture tree that backs raw downloads and contents listings
-	prs     map[int]prDef
-	openPRs []listPR // served by GET /repos/{o}/{r}/pulls for the prs command
+	srv        *httptest.Server
+	fixture    string // fixture tree that backs raw downloads and contents listings
+	prs        map[int]prDef
+	openPRs    []listPR     // served by GET /repos/{o}/{r}/pulls for the prs command
+	conflicted map[int]bool // PRs served with mergeable=false (and, like real GitHub, a stale merge_commit_sha)
 }
 
 func newMockGitHub(t *testing.T, fixtureDir string, prs []prDef) *mockGitHub {
@@ -256,10 +257,13 @@ func (m *mockGitHub) handleAPI(w http.ResponseWriter, rest []string) {
 			jsonNotFound(w)
 			return
 		}
+		// merge_commit_sha stays populated even when mergeable is false — real GitHub
+		// keeps serving the stale test-merge SHA for a PR that has become conflicted
 		writeJSON(w, map[string]any{
 			"number":           pr.number,
 			"state":            pr.state,
 			"title":            pr.title,
+			"mergeable":        !m.conflicted[n],
 			"merge_commit_sha": mergeSHA,
 		})
 

--- a/lib/gh/pr.go
+++ b/lib/gh/pr.go
@@ -1,9 +1,11 @@
 package gh
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/google/go-github/v89/github"
 	"github.com/katbyte/tctest/lib/clog"
@@ -36,6 +38,56 @@ func (r Repo) CheckoutPR(repoPath string, prNumber int) (string, error) {
 		return "", fmt.Errorf("failed to checkout merge commit: %w", err)
 	}
 	return sha, nil
+}
+
+// mergeableAttempts and mergeableRetryDelay control how long GetPrForBuild waits for
+// GitHub to finish computing a PR's mergeability (the computation is asynchronous and
+// a GET on the PR is what kicks it off).
+const (
+	mergeableAttempts   = 5
+	mergeableRetryDelay = 3 * time.Second
+)
+
+// GetPrForBuild fetches a PR and verifies builds can be triggered on its merge ref: it
+// must be open, mergeable, and have a merge commit SHA. Mergeable has to be checked
+// explicitly — GitHub keeps returning a stale merge_commit_sha for a PR that has
+// *become* conflicted, so a nil-SHA check alone lets conflicted PRs through to trigger
+// builds on a stale or missing refs/pull/N/merge ref, which then fail (or silently test
+// outdated code) inside TeamCity where nobody sees it.
+func (r Repo) GetPrForBuild(number int) (*github.PullRequest, error) {
+	client, ctx := r.NewClient()
+
+	for attempt := 1; ; attempt++ {
+		clog.Log.Debugf("fetching data for PR %s/%s/#%d...", r.Owner, r.Name, number)
+		pr, _, err := client.PullRequests.Get(ctx, r.Owner, r.Name, number)
+		if err != nil {
+			return nil, WrapGitHubError(err, fmt.Sprintf("fetching PR %s/%s/#%d", r.Owner, r.Name, number))
+		}
+
+		clog.Log.Debugf("  checking pr state: %v", pr.GetState())
+		if pr.GetState() == PRStateClosed {
+			return nil, errors.New("cannot start build for a closed pr")
+		}
+
+		if pr.Mergeable == nil {
+			if attempt < mergeableAttempts {
+				clog.Log.Debugf("  mergeability of PR #%d not yet computed by github, retrying (%d/%d)...", number, attempt, mergeableAttempts)
+				time.Sleep(mergeableRetryDelay)
+				continue
+			}
+			return nil, fmt.Errorf("github has not finished computing mergeability for PR #%d, try again shortly", number)
+		}
+
+		if !pr.GetMergeable() {
+			return nil, fmt.Errorf("PR #%d has merge conflicts that must be resolved before tests can be run", number)
+		}
+
+		if pr.MergeCommitSHA == nil {
+			return nil, fmt.Errorf("PR #%d is mergeable but github has no merge commit SHA for it yet, try again shortly", number)
+		}
+
+		return pr, nil
+	}
 }
 
 func (r Repo) ListAllPullRequests(state string, cb func([]*github.PullRequest, *github.Response) error) error {


### PR DESCRIPTION
- Check the PR's mergeable state (retrying while GitHub computes it) instead of relying on `merge_commit_sha`, which GitHub keeps serving stale for PRs that become conflicted — builds were being triggered on a stale/missing merge ref and failing invisibly inside TeamCity
- AST discovery verifies mergeability via the API before fetching the merge ref
- Exit non-zero with "no builds were triggered" when discovery finds nothing, so CI wrappers (the `/test` comment workflow) can't mistake a no-op for success