### PR TITLE
prs: use bare PR number instead of refs/pull/N/merge when triggering builds

### DIFF
--- a/cli/prs.go
+++ b/cli/prs.go
@@ -52,7 +52,9 @@ func (f FlagData) GetAndRunPrsTests(prs []int, testRegExParam string) error {
 				buildTypeID += "_" + strings.ToUpper(s)
 			}
 
-			branch := fmt.Sprintf("refs/pull/%d/merge", pri)
+			// todo doesn't work with new cloud VCS settings?
+			// branch := fmt.Sprintf("refs/pull/%d/merge", pri)
+			branch := fmt.Sprintf("%d", pri)
 
 			if err := f.BuildCmd(buildTypeID, branch, testRegEx, serviceInfo); err != nil {
 				c.Printf("  <red>ERROR: Unable to trigger build:</> %v\n", err)

--- a/cli/prs.go
+++ b/cli/prs.go
@@ -54,7 +54,7 @@ func (f FlagData) GetAndRunPrsTests(prs []int, testRegExParam string) error {
 
 			branch := fmt.Sprintf("refs/pull/%d/merge", pri)
 
-			if err := GetFlags().BuildCmd(buildTypeID, branch, testRegEx, serviceInfo); err != nil {
+			if err := f.BuildCmd(buildTypeID, branch, testRegEx, serviceInfo); err != nil {
 				c.Printf("  <red>ERROR: Unable to trigger build:</> %v\n", err)
 			}
 			fmt.Println()


### PR DESCRIPTION
Switches the `prs` command to pass the bare PR number as the branch instead of `refs/pull/N/merge`, since the refs form doesn't work with the new cloud VCS settings (per the in-code TODO). Also uses the receiver's `BuildCmd` instead of re-fetching flags via `GetFlags()`.

Note: these commits date from July 2023 and may need rebasing/re-validation against current main before merging.