### PR TITLE
error when a waited-on build was cancelled instead of reporting success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3.0 (unreleased)
+
+- `--wait` now errors when a build is cancelled (e.g. by TeamCity on a temporary VCS error) instead of treating it as a successful run with no results, and includes TeamCity's cancellation reason ([#31](https://github.com/katbyte/tctest/issues/31))
+
 ## v1.2.0 (2026-08-10)
 
 - add `--force`/`-f` flag to bypass the `--max-builds-per-pr` check ([#107](https://github.com/katbyte/tctest/pull/107))

--- a/lib/tc/build.go
+++ b/lib/tc/build.go
@@ -145,11 +145,57 @@ func (s Server) WaitForBuild(buildID, queueTimeout, runTimeout int) error {
 		}
 
 		if body == "finished" {
-			return nil
+			// 'finished' alone isn't success — cancelled builds (e.g. TeamCity hitting a temporary VCS error like
+			// "cannot find commit") also report state 'finished', and would otherwise look like a clean run with no results
+			return s.CheckFinishedBuild(buildID)
 		}
 
 		time.Sleep(1 * time.Minute)
 	}
+}
+
+// finishedBuildResp is the subset of a build's detail needed to tell a cancelled build apart from one that ran
+type finishedBuildResp struct {
+	XMLName      xml.Name `xml:"build"`
+	Status       string   `xml:"status,attr"`
+	StatusText   string   `xml:"statusText"`
+	CanceledInfo *struct {
+		Text string `xml:"text"`
+	} `xml:"canceledInfo"`
+}
+
+// CheckFinishedBuild returns an error if a finished build was cancelled instead of run to completion, including
+// TeamCity's cancellation reason when it provides one. Cancelled builds carry a canceledInfo element and status
+// UNKNOWN, either of which is treated as cancellation.
+func (s Server) CheckFinishedBuild(buildID int) error {
+	statusCode, body, err := s.makeGetRequest(fmt.Sprintf("/app/rest/2018.1/builds/%d", buildID))
+	if err != nil {
+		return fmt.Errorf("error fetching status for build %d: %w", buildID, err)
+	}
+	if statusCode != http.StatusOK {
+		return fmt.Errorf("HTTP status NOT OK: %d fetching status for build %d", statusCode, buildID)
+	}
+
+	var build finishedBuildResp
+	if err := xml.Unmarshal([]byte(body), &build); err != nil {
+		return fmt.Errorf("unable to decode XML for build %d: %w", buildID, err)
+	}
+
+	if build.CanceledInfo == nil && build.Status != "UNKNOWN" {
+		return nil
+	}
+
+	reason := ""
+	if build.CanceledInfo != nil {
+		reason = build.CanceledInfo.Text
+	}
+	if reason == "" {
+		reason = build.StatusText
+	}
+	if reason == "" {
+		return fmt.Errorf("build %d was cancelled", buildID)
+	}
+	return fmt.Errorf("build %d was cancelled: %s", buildID, reason)
 }
 
 func (s Server) CheckBuildLogStatus(statusCode, buildID int) error {

--- a/lib/tc/build_test.go
+++ b/lib/tc/build_test.go
@@ -1,6 +1,12 @@
 package tc
 
-import "testing"
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 func TestXmlEscape(t *testing.T) {
 	t.Parallel()
@@ -17,5 +23,67 @@ func TestXmlEscape(t *testing.T) {
 		if got := xmlEscape(in); got != want {
 			t.Errorf("xmlEscape(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestCheckFinishedBuild(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		body    string
+		wantErr string // substring the error must contain, "" for no error
+	}{
+		"successful build": {
+			body: `<build id="123" state="finished" status="SUCCESS"><statusText>Tests passed: 4</statusText></build>`,
+		},
+		"failed build is not cancelled": {
+			body: `<build id="123" state="finished" status="FAILURE"><statusText>Tests failed: 1</statusText></build>`,
+		},
+		"cancelled with canceledInfo text": {
+			body: `<build id="123" state="finished" status="UNKNOWN"><statusText>Canceled</statusText>` +
+				`<canceledInfo timestamp="20200521T000000+0000"><text>Failed to collect changes: cannot find commit</text></canceledInfo></build>`,
+			wantErr: "build 123 was cancelled: Failed to collect changes: cannot find commit",
+		},
+		"cancelled without canceledInfo text falls back to statusText": {
+			body: `<build id="123" state="finished" status="UNKNOWN"><statusText>Canceled</statusText>` +
+				`<canceledInfo timestamp="20200521T000000+0000"/></build>`,
+			wantErr: "build 123 was cancelled: Canceled",
+		},
+		"cancelled with no reason at all": {
+			body:    `<build id="123" state="finished" status="UNKNOWN"><canceledInfo/></build>`,
+			wantErr: "build 123 was cancelled",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/app/rest/2018.1/builds/123" {
+					http.NotFound(w, r)
+					return
+				}
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			defer ts.Close()
+
+			token := "t"
+			s := Server{Server: ts.URL, token: &token}
+
+			err := s.CheckFinishedBuild(123)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckFinishedBuild() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckFinishedBuild() = nil, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("CheckFinishedBuild() = %q, want error containing %q", err, tc.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #31

TeamCity cancels builds itself on e.g. temporary VCS errors ("cannot find commit"), and a cancelled build still reaches state `finished` — so `--wait` treated it as a clean run and exited 0 with no results and no indication anything went wrong.

After `WaitForBuild` sees `finished`, it now fetches the build's detail via `/app/rest/2018.1/builds/<id>` and errors if the build carries `canceledInfo` (or status `UNKNOWN`), including TeamCity's cancellation reason in the message:

```
error waiting for build 123 to finish: build 123 was cancelled: Failed to collect changes: cannot find commit
```

This covers all three wait paths (`pr --wait`, `results --wait`, and per-PR results) since they all go through `WaitForBuild`. Includes unit tests against a mock TeamCity server for the success / failure / cancelled cases.

The issue also suggested an override flag to warn-and-continue; that made sense when tctest scanned the log of the last mergeable commit's build, but for a cancelled build there are no results to continue to, so it's omitted.