### PR TITLE
add --individual/-i flag to discover only the test functions a PR modifies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 - error clearly when a PR has merge conflicts: check the PR's `mergeable` state (retrying while GitHub computes it) instead of relying on `merge_commit_sha`, which GitHub keeps serving stale for PRs that become conflicted — previously builds were triggered on a stale or missing merge ref and failed invisibly inside TeamCity
 - exit non-zero with `no builds were triggered` when discovery finds nothing to run, so CI wrappers (e.g. the azurerm `/test` comment workflow) report it instead of treating a no-op run as success
 - the AST discovery path verifies mergeability via the API before fetching the merge ref, which could otherwise succeed on a stale ref
-
-## v1.3.0 (unreleased)
-
 - add `--individual`/`-i` flag: for directly changed test files, discover only the individual test functions the PR modifies (by intersecting the PR diff with parsed test declarations) instead of split prefixes that match the whole test family; indirectly discovered test files keep prefix discovery ([#38](https://github.com/katbyte/tctest/issues/38))
 
 ## v1.2.0 (2026-08-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - exit non-zero with `no builds were triggered` when discovery finds nothing to run, so CI wrappers (e.g. the azurerm `/test` comment workflow) report it instead of treating a no-op run as success
 - the AST discovery path verifies mergeability via the API before fetching the merge ref, which could otherwise succeed on a stale ref
 
+## v1.3.0 (unreleased)
+
+- add `--individual`/`-i` flag: for directly changed test files, discover only the individual test functions the PR modifies (by intersecting the PR diff with parsed test declarations) instead of split prefixes that match the whole test family; indirectly discovered test files keep prefix discovery ([#38](https://github.com/katbyte/tctest/issues/38))
+
 ## v1.2.0 (2026-08-10)
 
 - add `--force`/`-f` flag to bypass the `--max-builds-per-pr` check ([#107](https://github.com/katbyte/tctest/pull/107))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - error clearly when a PR has merge conflicts: check the PR's `mergeable` state (retrying while GitHub computes it) instead of relying on `merge_commit_sha`, which GitHub keeps serving stale for PRs that become conflicted — previously builds were triggered on a stale or missing merge ref and failed invisibly inside TeamCity
 - exit non-zero with `no builds were triggered` when discovery finds nothing to run, so CI wrappers (e.g. the azurerm `/test` comment workflow) report it instead of treating a no-op run as success
 - the AST discovery path verifies mergeability via the API before fetching the merge ref, which could otherwise succeed on a stale ref
-- add `--individual`/`-i` flag: for directly changed test files, discover only the individual test functions the PR modifies (by intersecting the PR diff with parsed test declarations) instead of split prefixes that match the whole test family; indirectly discovered test files keep prefix discovery ([#38](https://github.com/katbyte/tctest/issues/38))
+- add `--individual`/`-i` flag to discover individual test functions by full name instead of split prefixes: directly changed test files yield only the tests the PR modifies (by intersecting the PR diff with parsed test declarations), while indirectly discovered test files (e.g. via a changed resource) yield every test they contain ([#38](https://github.com/katbyte/tctest/issues/38))
 
 ## v1.2.0 (2026-08-10)
 

--- a/README.md
+++ b/README.md
@@ -223,13 +223,13 @@ tctest list 3232 -r hashicorp/terraform-provider-aws
 For custom usecases, you can override `--fileregex` and `--acctest-file-suffix-regexes` flags.
 run `tctest --help` to see their defaults.
 
-By default a changed test file contributes all of its tests as split prefixes (e.g. `TestAccAWSInstance`, which matches
-the whole test family). With `--individual`/`-i`, tctest reads the PR diff and narrows directly changed test files to
-just the test functions the PR actually modifies, listed by their full names:
+By default a changed test file contributes all of its tests as split prefixes (e.g. `TestAccPostgresqlFlexibleServer`,
+which matches the whole test family). With `--individual`/`-i`, tctest reads the PR diff and narrows directly changed
+test files to just the test functions the PR actually modifies, listed by their full names:
 
 ```bash
 tctest list -i 3232
-# TestAccAWSInstance_RootBlockDevice_KmsKeyArn
+# TestAccPostgresqlFlexibleServer_complete
 ```
 
 Test files discovered indirectly (e.g. via a changed resource file, where any of the resource's tests could be

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Create a file like [`set_env_example.sh`](.github/images/set_env_example.sh) and
 | `TCTEST_ACCTEST_FILE_SUFFIX_REGEXES` | `--acctest-file-suffix-regexes` | Comma-separated regex suffix (without `.go`) to find relevant acceptance-test files for a resource. |
 | `TCTEST_SPLIT_TESTS_ON` | `--splitteston` | Character to split test names on (default: `_`) |
 | `TCTEST_REAPPEND_SPLIT_CHARACTER` | `--reappend-split-character` | Whether to append the split character to the resulting test filter for more precise filtering |
+| `TCTEST_INDIVIDUAL` | `--individual`, `-i` | For directly changed test files, discover only the individual test functions the PR modifies (full names instead of prefixes) |
 | `TCTEST_WAIT` | `--wait`, `-w` | Wait for builds to complete |
 | `TCTEST_LATESTBUILD` | `--latest` | Get the latest build |
 | `TCTEST_SKIP_QUEUE` | `--skip-queue`, `-q` | Put the build to the top of the queue |
@@ -221,6 +222,18 @@ tctest list 3232 -r hashicorp/terraform-provider-aws
 ```
 For custom usecases, you can override `--fileregex` and `--acctest-file-suffix-regexes` flags.
 run `tctest --help` to see their defaults.
+
+By default a changed test file contributes all of its tests as split prefixes (e.g. `TestAccAWSInstance`, which matches
+the whole test family). With `--individual`/`-i`, tctest reads the PR diff and narrows directly changed test files to
+just the test functions the PR actually modifies, listed by their full names:
+
+```bash
+tctest list -i 3232
+# TestAccAWSInstance_RootBlockDevice_KmsKeyArn
+```
+
+Test files discovered indirectly (e.g. via a changed resource file, where any of the resource's tests could be
+affected) keep the prefix behaviour. The flag also works with `pr` and `prs` to trigger only the modified tests.
 
 ### `results` — Show build results
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Create a file like [`set_env_example.sh`](.github/images/set_env_example.sh) and
 | `TCTEST_ACCTEST_FILE_SUFFIX_REGEXES` | `--acctest-file-suffix-regexes` | Comma-separated regex suffix (without `.go`) to find relevant acceptance-test files for a resource. |
 | `TCTEST_SPLIT_TESTS_ON` | `--splitteston` | Character to split test names on (default: `_`) |
 | `TCTEST_REAPPEND_SPLIT_CHARACTER` | `--reappend-split-character` | Whether to append the split character to the resulting test filter for more precise filtering |
-| `TCTEST_INDIVIDUAL` | `--individual`, `-i` | For directly changed test files, discover only the individual test functions the PR modifies (full names instead of prefixes) |
+| `TCTEST_INDIVIDUAL` | `--individual`, `-i` | Discover individual test functions by full name instead of split prefixes: directly changed test files yield only the tests the PR modifies, indirectly discovered files yield every test they contain |
 | `TCTEST_WAIT` | `--wait`, `-w` | Wait for builds to complete |
 | `TCTEST_LATESTBUILD` | `--latest` | Get the latest build |
 | `TCTEST_SKIP_QUEUE` | `--skip-queue`, `-q` | Put the build to the top of the queue |
@@ -232,8 +232,9 @@ tctest list -i 3232
 # TestAccPostgresqlFlexibleServer_complete
 ```
 
-Test files discovered indirectly (e.g. via a changed resource file, where any of the resource's tests could be
-affected) keep the prefix behaviour. The flag also works with `pr` and `prs` to trigger only the modified tests.
+With `-i`, prefixes are never used: test files discovered indirectly (e.g. via a changed resource file, where any of
+the resource's tests could be affected) list every test function they contain, by full name. The flag also works with
+`pr` and `prs` to trigger only the discovered tests.
 
 ### `results` — Show build results
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -92,6 +92,7 @@ type DiscoveryConfig struct {
 	FileRegEx                *regexp.Regexp   `mapstructure:"-"`
 	SplitTestsOn             string           `mapstructure:"splitteston"`
 	ReappendSplitCharacter   bool             `mapstructure:"reappend-split-character"`
+	IndividualTests          bool             `mapstructure:"individual"`
 	AccTestFileSuffixRegexes []*regexp.Regexp `mapstructure:"-"`
 	Concurrency              int              `mapstructure:"concurrency"`
 	CollapseFilesAfter       int              `mapstructure:"collapse-files-after"`
@@ -177,6 +178,7 @@ func configureFlags(root *cobra.Command) error {
 		`^_data_source_test$`,  // data-source tests (both providers)
 	}, "comma-separated list of regex patterns to match acceptance test filenames suffix (without '.go')")
 	pflags.Bool("reappend-split-character", false, "whether to append the split character to the resulting test filter for more precise filtering")
+	pflags.BoolP("individual", "i", false, "discover the individual test functions a PR modifies in directly changed test files (full names instead of prefixes); files discovered indirectly (e.g. via a changed resource) keep prefix discovery")
 	pflags.Int("concurrency", 5, "maximum number of concurrent file downloads during test discovery")
 	pflags.Int("collapse-files-after", 20, "collapse file listings to a count when there are more than this many files (0 to always show)")
 
@@ -247,6 +249,7 @@ func configureFlags(root *cobra.Command) error {
 		"acctest-file-suffix-regexes":      "TCTEST_ACCTEST_FILE_SUFFIX_REGEXES",
 		"splitteston":                      "TCTEST_SPLIT_TESTS_ON",
 		"reappend-split-character":         "TCTEST_REAPPEND_SPLIT_CHARACTER",
+		"individual":                       "TCTEST_INDIVIDUAL",
 		"wait":                             "TCTEST_WAIT",
 		"all":                              "",
 		"service":                          "",

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -178,7 +178,7 @@ func configureFlags(root *cobra.Command) error {
 		`^_data_source_test$`,  // data-source tests (both providers)
 	}, "comma-separated list of regex patterns to match acceptance test filenames suffix (without '.go')")
 	pflags.Bool("reappend-split-character", false, "whether to append the split character to the resulting test filter for more precise filtering")
-	pflags.BoolP("individual", "i", false, "discover the individual test functions a PR modifies in directly changed test files (full names instead of prefixes); files discovered indirectly (e.g. via a changed resource) keep prefix discovery")
+	pflags.BoolP("individual", "i", false, "discover individual test functions by full name instead of split prefixes: directly changed test files yield only the tests the PR modifies, files discovered indirectly (e.g. via a changed resource) yield every test they contain")
 	pflags.Int("concurrency", 5, "maximum number of concurrent file downloads during test discovery")
 	pflags.Int("collapse-files-after", 20, "collapse file listings to a count when there are more than this many files (0 to always show)")
 

--- a/cli/pr-ast.go
+++ b/cli/pr-ast.go
@@ -860,7 +860,7 @@ func (dc *AstDiscoveryContext) ParseTestsConcurrently() (map[string][]string, er
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			tests, err := extractTests(pfile, dc.Config)
+			tests, err := pfile.DiscoverTests(dc.Config.SplitTestsOn, dc.Config.ReappendSplitCharacter, dc.Config.IndividualTests)
 			if err != nil {
 				mu.Lock()
 				errs = append(errs, err)

--- a/cli/pr-ast.go
+++ b/cli/pr-ast.go
@@ -444,7 +444,7 @@ func (dc *AstDiscoveryContext) CollectChangedFiles(ghr GithubRepo, pri int) (res
 				dc.ChangedFileLines = append(dc.ChangedFileLines, fmt.Sprintf("    %s <darkGray>%s</>\n", pf.ColouredFileName(), pf.TypeLabel()))
 
 			case provider.FileTypeTest:
-
+				pf.SetPatch(f.GetPatch()) // keep the diff so --individual can narrow discovery to the modified test functions
 				dc.AddTestFile(pf, "CHANGED")
 				dc.ChangedFileLines = append(dc.ChangedFileLines, fmt.Sprintf("    %s <darkGray>[TEST]</>\n", pf.ColouredFileName()))
 
@@ -860,7 +860,7 @@ func (dc *AstDiscoveryContext) ParseTestsConcurrently() (map[string][]string, er
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			tests, err := pfile.ExtractTests(dc.Config.SplitTestsOn, dc.Config.ReappendSplitCharacter)
+			tests, err := extractTests(pfile, dc.Config)
 			if err != nil {
 				mu.Lock()
 				errs = append(errs, err)

--- a/cli/pr.go
+++ b/cli/pr.go
@@ -83,27 +83,6 @@ func (f *FlagData) GetPrTests(number int, title string) (map[string][]string, er
 	return serviceTests, nil
 }
 
-// extractTests extracts test names from a discovered test file honouring --individual: a directly changed test file
-// (which carries its PR patch) yields only the full names of the test functions the PR modifies, while everything else
-// (and --individual off) falls back to ExtractTests' split-prefix behaviour.
-func extractTests(pf *provider.File, cfg DiscoveryConfig) ([]string, error) {
-	if cfg.IndividualTests {
-		tests, ok, err := pf.ExtractChangedTests()
-		if err != nil {
-			return nil, err
-		}
-		if ok && len(tests) > 0 {
-			return tests, nil
-		}
-		if ok {
-			// the diff only touched non-test code in the file (e.g. a shared helper), so any of its tests could be
-			// affected — better to fall back to whole-file discovery than silently discover nothing
-			clog.Log.Debugf("    %s: no test functions overlap the PR diff, falling back to whole-file discovery", pf.RelPath)
-		}
-	}
-	return pf.ExtractTests(cfg.SplitTestsOn, cfg.ReappendSplitCharacter)
-}
-
 // PrTestsFromAPI fetches the list of files changed in a PR and determines which tests should be run.
 // It uses GetPullRequestTestFiles to get the files, groups them into packages, and returns a map of package names to a list of test names.
 func (ghr GithubRepo) PrTestsFromAPI(pri int, cfg DiscoveryConfig) (map[string][]string, error) {
@@ -159,7 +138,7 @@ func (ghr GithubRepo) PrTestsFromAPI(pri int, cfg DiscoveryConfig) (map[string][
 			}
 
 			f.SetContent(content)
-			tests, err := extractTests(&f, cfg)
+			tests, err := f.DiscoverTests(cfg.SplitTestsOn, cfg.ReappendSplitCharacter, cfg.IndividualTests)
 			if err != nil {
 				mu.Lock()
 				errs = append(errs, err)

--- a/cli/pr.go
+++ b/cli/pr.go
@@ -83,6 +83,27 @@ func (f *FlagData) GetPrTests(number int, title string) (map[string][]string, er
 	return serviceTests, nil
 }
 
+// extractTests extracts test names from a discovered test file honouring --individual: a directly changed test file
+// (which carries its PR patch) yields only the full names of the test functions the PR modifies, while everything else
+// (and --individual off) falls back to ExtractTests' split-prefix behaviour.
+func extractTests(pf *provider.File, cfg DiscoveryConfig) ([]string, error) {
+	if cfg.IndividualTests {
+		tests, ok, err := pf.ExtractChangedTests()
+		if err != nil {
+			return nil, err
+		}
+		if ok && len(tests) > 0 {
+			return tests, nil
+		}
+		if ok {
+			// the diff only touched non-test code in the file (e.g. a shared helper), so any of its tests could be
+			// affected — better to fall back to whole-file discovery than silently discover nothing
+			clog.Log.Debugf("    %s: no test functions overlap the PR diff, falling back to whole-file discovery", pf.RelPath)
+		}
+	}
+	return pf.ExtractTests(cfg.SplitTestsOn, cfg.ReappendSplitCharacter)
+}
+
 // PrTestsFromAPI fetches the list of files changed in a PR and determines which tests should be run.
 // It uses GetPullRequestTestFiles to get the files, groups them into packages, and returns a map of package names to a list of test names.
 func (ghr GithubRepo) PrTestsFromAPI(pri int, cfg DiscoveryConfig) (map[string][]string, error) {
@@ -138,7 +159,7 @@ func (ghr GithubRepo) PrTestsFromAPI(pri int, cfg DiscoveryConfig) (map[string][
 			}
 
 			f.SetContent(content)
-			tests, err := f.ExtractTests(cfg.SplitTestsOn, cfg.ReappendSplitCharacter)
+			tests, err := extractTests(&f, cfg)
 			if err != nil {
 				mu.Lock()
 				errs = append(errs, err)
@@ -251,6 +272,7 @@ func (ghr GithubRepo) GetPullRequestTestFiles(pri int, cfg DiscoveryConfig) ([]p
 			}
 
 			if pf.Type == provider.FileTypeTest {
+				pf.SetPatch(f.GetPatch()) // keep the diff so --individual can narrow discovery to the modified test functions
 				changedServiceFiles = append(changedServiceFiles, pf)
 				addTestFile(pf, "CHANGED")
 				continue

--- a/integration/integration_aws_test.go
+++ b/integration/integration_aws_test.go
@@ -7,32 +7,32 @@ import (
 
 var awsPRs = []prDef{
 	{10001, "open", "changed resource file", []changedFile{
-		{"internal/service/rekognition/collection.go", "modified"},
+		{"internal/service/rekognition/collection.go", "modified", ""},
 	}},
 	{10002, "open", "two resources one service", []changedFile{
-		{"internal/service/rekognition/collection.go", "modified"},
-		{"internal/service/rekognition/project.go", "modified"},
+		{"internal/service/rekognition/collection.go", "modified", ""},
+		{"internal/service/rekognition/project.go", "modified", ""},
 	}},
 	{10003, "open", "changed sdk resource without _resource suffix", []changedFile{
-		{"internal/service/s3/bucket.go", "modified"},
+		{"internal/service/s3/bucket.go", "modified", ""},
 	}},
 	{10004, "open", "changed test file", []changedFile{
-		{"internal/service/s3/bucket_test.go", "modified"},
+		{"internal/service/s3/bucket_test.go", "modified", ""},
 	}},
 	{10005, "open", "multiple services", []changedFile{
-		{"internal/service/rekognition/collection.go", "modified"},
-		{"internal/service/s3/bucket.go", "modified"},
+		{"internal/service/rekognition/collection.go", "modified", ""},
+		{"internal/service/s3/bucket.go", "modified", ""},
 	}},
 	{10006, "open", "generated and export files only", []changedFile{
-		{"internal/service/rekognition/service_package_gen.go", "modified"},
-		{"internal/service/rekognition/exports_test.go", "modified"},
-		{"internal/service/rekognition/tags_gen.go", "modified"},
+		{"internal/service/rekognition/service_package_gen.go", "modified", ""},
+		{"internal/service/rekognition/exports_test.go", "modified", ""},
+		{"internal/service/rekognition/tags_gen.go", "modified", ""},
 	}},
 	{10007, "open", "changed plural data source", []changedFile{
-		{"internal/service/s3/buckets_data_source.go", "modified"},
+		{"internal/service/s3/buckets_data_source.go", "modified", ""},
 	}},
 	{10008, "open", "changed flat migrate helper", []changedFile{
-		{"internal/service/rekognition/stream_processor_migrate.go", "modified"},
+		{"internal/service/rekognition/stream_processor_migrate.go", "modified", ""},
 	}},
 }
 
@@ -40,19 +40,19 @@ var awsPRs = []prDef{
 // numbers exist in the aws git fixture upstream.
 var awsASTPRs = []prDef{
 	{20001, "open", "changed sdk resource without _resource suffix", []changedFile{
-		{"internal/service/s3/bucket.go", "modified"},
+		{"internal/service/s3/bucket.go", "modified", ""},
 	}},
 	{20002, "open", "changed framework resource", []changedFile{
-		{"internal/service/rekognition/stream_processor.go", "modified"},
+		{"internal/service/rekognition/stream_processor.go", "modified", ""},
 	}},
 	{20003, "open", "multiple services", []changedFile{
-		{"internal/service/rekognition/collection.go", "modified"},
-		{"internal/service/s3/bucket.go", "modified"},
+		{"internal/service/rekognition/collection.go", "modified", ""},
+		{"internal/service/s3/bucket.go", "modified", ""},
 	}},
 	{20004, "open", "generated and export files only", []changedFile{
-		{"internal/service/rekognition/service_package_gen.go", "modified"},
-		{"internal/service/rekognition/exports_test.go", "modified"},
-		{"internal/service/rekognition/tags_gen.go", "modified"},
+		{"internal/service/rekognition/service_package_gen.go", "modified", ""},
+		{"internal/service/rekognition/exports_test.go", "modified", ""},
+		{"internal/service/rekognition/tags_gen.go", "modified", ""},
 	}},
 }
 

--- a/integration/integration_azurerm_test.go
+++ b/integration/integration_azurerm_test.go
@@ -11,40 +11,40 @@ import (
 // azurermPRs defines the PRs the mock GitHub serves for the azurerm fixture.
 var azurermPRs = []prDef{
 	{1001, "open", "changed test file", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", "@@ -55,3 +55,3 @@"},
 	}},
 	{1002, "open", "changed resource file", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource.go", "modified", ""},
 	}},
 	{1003, "open", "changed cross-package helper only", []changedFile{
-		{"internal/services/postgres/validate/database_charset.go", "modified"},
+		{"internal/services/postgres/validate/database_charset.go", "modified", ""},
 	}},
 	{1004, "open", "multiple services", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
-		{"internal/services/dns/dns_a_record_resource.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", ""},
+		{"internal/services/dns/dns_a_record_resource.go", "modified", ""},
 	}},
 	{1005, "closed", "closed pr", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", ""},
 	}},
 	{1006, "open", "changed untyped data source", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_data_source.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_data_source.go", "modified", ""},
 	}},
 	{1007, "open", "changed typed data source", []changedFile{
-		{"internal/services/dns/dns_zone_data_source.go", "modified"},
+		{"internal/services/dns/dns_zone_data_source.go", "modified", ""},
 	}},
 	{1008, "open", "mixed resource, test, and helper", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource.go", "modified"},
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
-		{"internal/services/postgres/validate/database_charset.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource.go", "modified", ""},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", ""},
+		{"internal/services/postgres/validate/database_charset.go", "modified", ""},
 	}},
 	{1009, "open", "conflicted pr", []changedFile{
 		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
 	}},
 	{1020, "open", "postgres improvement", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", ""},
 	}},
 	{1021, "open", "dns bug fix", []changedFile{
-		{"internal/services/dns/dns_a_record_resource.go", "modified"},
+		{"internal/services/dns/dns_a_record_resource.go", "modified", ""},
 	}},
 }
 
@@ -52,40 +52,40 @@ var azurermPRs = []prDef{
 // numbers exist in the git fixture upstream.
 var azurermASTPRs = []prDef{
 	{2001, "open", "same-package helper changed", []changedFile{
-		{"internal/services/dns/ipv6_address.go", "modified"},
+		{"internal/services/dns/ipv6_address.go", "modified", ""},
 	}},
 	{2002, "open", "cross-package helper changed", []changedFile{
-		{"internal/services/postgres/validate/database_charset.go", "modified"},
+		{"internal/services/postgres/validate/database_charset.go", "modified", ""},
 	}},
 	{2003, "open", "two-level helper chain changed", []changedFile{
-		{"internal/services/postgres/parse/postgresql_aad_administrator.go", "modified"},
+		{"internal/services/postgres/parse/postgresql_aad_administrator.go", "modified", ""},
 	}},
 	{2004, "open", "vendored dependency changed", []changedFile{
-		{"vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb/client.go", "modified"},
+		{"vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb/client.go", "modified", ""},
 	}},
 	{2005, "open", "changed test file", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", "@@ -55,3 +55,3 @@"},
 	}},
 	{2006, "open", "changed resource file", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource.go", "modified", ""},
 	}},
 	{2007, "open", "multiple services", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
-		{"internal/services/dns/dns_a_record_resource.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", ""},
+		{"internal/services/dns/dns_a_record_resource.go", "modified", ""},
 	}},
 	{2008, "closed", "closed pr", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", ""},
 	}},
 	{2009, "open", "changed untyped data source", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_data_source.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_data_source.go", "modified", ""},
 	}},
 	{2010, "open", "changed typed data source", []changedFile{
-		{"internal/services/dns/dns_zone_data_source.go", "modified"},
+		{"internal/services/dns/dns_zone_data_source.go", "modified", ""},
 	}},
 	{2011, "open", "mixed resource, test, and helper", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource.go", "modified"},
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
-		{"internal/services/postgres/validate/database_charset.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource.go", "modified", ""},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", ""},
+		{"internal/services/postgres/validate/database_charset.go", "modified", ""},
 	}},
 	{2012, "open", "conflicted pr", []changedFile{
 		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
@@ -167,6 +167,11 @@ func TestAPIDiscoveryAzureRM(t *testing.T) {
 			name: "explicit test regex overrides discovery",
 			args: []string{"pr", "1001", "TestAccPostgresqlFlexibleServer_complete"},
 			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/1001/merge", "TestAccPostgresqlFlexibleServer_complete"}},
+		},
+		{
+			name: "individual flag narrows changed test file to the modified test functions",
+			args: []string{"pr", "1001", "-i"},
+			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/1001/merge", "(TestAccPostgresqlFlexibleServer_complete)"}},
 		},
 		{
 			name: "--all overrides the discovered regex with TestAcc",
@@ -274,6 +279,11 @@ func TestASTDiscoveryAzureRM(t *testing.T) {
 			name: "cross-package helper traces through import symbol usage",
 			args: []string{"pr", "2002"},
 			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/2002/merge", "(TestAccPostgresqlFlexibleServerDatabase)"}},
+		},
+		{
+			name: "individual flag narrows changed test file to the modified test functions",
+			args: []string{"pr", "2005", "-i"},
+			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/2005/merge", "(TestAccPostgresqlFlexibleServer_complete)"}},
 		},
 		{
 			name: "two-level helper chain traces only symbol users",

--- a/integration/integration_azurerm_test.go
+++ b/integration/integration_azurerm_test.go
@@ -38,7 +38,7 @@ var azurermPRs = []prDef{
 		{"internal/services/postgres/validate/database_charset.go", "modified", ""},
 	}},
 	{1009, "open", "conflicted pr", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", ""},
 	}},
 	{1020, "open", "postgres improvement", []changedFile{
 		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", ""},
@@ -88,7 +88,7 @@ var azurermASTPRs = []prDef{
 		{"internal/services/postgres/validate/database_charset.go", "modified", ""},
 	}},
 	{2012, "open", "conflicted pr", []changedFile{
-		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified"},
+		{"internal/services/postgres/postgresql_flexible_server_resource_test.go", "modified", ""},
 	}},
 }
 

--- a/integration/integration_azurerm_test.go
+++ b/integration/integration_azurerm_test.go
@@ -174,6 +174,11 @@ func TestAPIDiscoveryAzureRM(t *testing.T) {
 			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/1001/merge", "(TestAccPostgresqlFlexibleServer_complete)"}},
 		},
 		{
+			name: "individual flag lists every test of derived files by full name",
+			args: []string{"pr", "1002", "-i"},
+			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/1002/merge", "(TestAccDataSourcePostgresqlflexibleServer_basic|TestAccPostgresqlFlexibleServer_basic|TestAccPostgresqlFlexibleServer_complete|TestAccPostgresqlFlexibleServer_requiresImport)"}},
+		},
+		{
 			name: "--all overrides the discovered regex with TestAcc",
 			args: []string{"pr", "1001", "--all"},
 			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/1001/merge", "TestAcc"}},
@@ -284,6 +289,11 @@ func TestASTDiscoveryAzureRM(t *testing.T) {
 			name: "individual flag narrows changed test file to the modified test functions",
 			args: []string{"pr", "2005", "-i"},
 			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/2005/merge", "(TestAccPostgresqlFlexibleServer_complete)"}},
+		},
+		{
+			name: "individual flag lists every test of derived files by full name",
+			args: []string{"pr", "2006", "-i"},
+			want: []trigger{{"TF_E2E_POSTGRES", "refs/pull/2006/merge", "(TestAccDataSourcePostgresqlflexibleServer_basic|TestAccPostgresqlFlexibleServer_basic|TestAccPostgresqlFlexibleServer_complete|TestAccPostgresqlFlexibleServer_requiresImport)"}},
 		},
 		{
 			name: "two-level helper chain traces only symbol users",

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -157,6 +157,7 @@ func cloneUpstream(t *testing.T, upstream string) string {
 type changedFile struct {
 	path   string
 	status string // "modified", "added", "removed"
+	patch  string // unified diff served in the files listing, used by --individual test discovery
 }
 
 type prDef struct {
@@ -277,7 +278,11 @@ func (m *mockGitHub) handleAPI(w http.ResponseWriter, rest []string) {
 		}
 		files := make([]map[string]any, 0, len(pr.files))
 		for _, f := range pr.files {
-			files = append(files, map[string]any{"filename": f.path, "status": f.status})
+			entry := map[string]any{"filename": f.path, "status": f.status}
+			if f.patch != "" {
+				entry["patch"] = f.patch
+			}
+			files = append(files, entry)
 		}
 		writeJSON(w, files)
 

--- a/lib/provider/file-tests.go
+++ b/lib/provider/file-tests.go
@@ -122,26 +122,38 @@ func (f *File) changedLineRanges() []lineRange {
 	return ranges
 }
 
-// DiscoverTests extracts a file's test names for build triggering. With individual set, a directly changed test file
-// (which carries its PR patch) yields only the full names of the test functions the PR modifies; everything else —
-// individual off, no patch (e.g. a file discovered via a sibling resource), or a diff touching only non-test code —
-// falls back to ExtractTests' split-prefix behaviour over the whole file.
+// DiscoverTests extracts a file's test names for build triggering. With individual set, only full test function
+// names are ever returned — never split prefixes: a directly changed test file (which carries its PR patch) yields
+// just the test functions the PR modifies, while a file without a patch (e.g. discovered via a sibling resource) or
+// one whose diff touches only non-test code yields every test function in the file. With individual off, all files
+// get ExtractTests' split-prefix behaviour.
 func (f *File) DiscoverTests(splitOn string, reappend, individual bool) ([]string, error) {
-	if individual {
-		tests, ok, err := f.ExtractChangedTests()
-		if err != nil {
-			return nil, err
-		}
-		if ok && len(tests) > 0 {
-			return tests, nil
-		}
-		if ok {
-			// the diff only touched non-test code in the file (e.g. a shared helper), so any of its tests could be
-			// affected — better to fall back to whole-file discovery than silently discover nothing
-			clog.Log.Debugf("    %s: no test functions overlap the PR diff, falling back to whole-file discovery", f.RelPath)
-		}
+	if !individual {
+		return f.ExtractTests(splitOn, reappend)
 	}
-	return f.ExtractTests(splitOn, reappend)
+
+	tests, ok, err := f.ExtractChangedTests()
+	if err != nil {
+		return nil, err
+	}
+	if ok && len(tests) > 0 {
+		return tests, nil
+	}
+	if ok {
+		// the diff only touched non-test code in the file (e.g. a shared helper), so any of its tests could be
+		// affected — better to fall back to every test in the file than silently discover nothing
+		clog.Log.Debugf("    %s: no test functions overlap the PR diff, falling back to all tests in the file", f.RelPath)
+	}
+
+	funcs, err := f.testFuncs()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(funcs))
+	for _, fn := range funcs {
+		names = append(names, fn.Name)
+	}
+	return names, nil
 }
 
 // ExtractChangedTests returns the full (unsplit) names of the acceptance test functions whose declarations overlap

--- a/lib/provider/file-tests.go
+++ b/lib/provider/file-tests.go
@@ -122,6 +122,28 @@ func (f *File) changedLineRanges() []lineRange {
 	return ranges
 }
 
+// DiscoverTests extracts a file's test names for build triggering. With individual set, a directly changed test file
+// (which carries its PR patch) yields only the full names of the test functions the PR modifies; everything else —
+// individual off, no patch (e.g. a file discovered via a sibling resource), or a diff touching only non-test code —
+// falls back to ExtractTests' split-prefix behaviour over the whole file.
+func (f *File) DiscoverTests(splitOn string, reappend, individual bool) ([]string, error) {
+	if individual {
+		tests, ok, err := f.ExtractChangedTests()
+		if err != nil {
+			return nil, err
+		}
+		if ok && len(tests) > 0 {
+			return tests, nil
+		}
+		if ok {
+			// the diff only touched non-test code in the file (e.g. a shared helper), so any of its tests could be
+			// affected — better to fall back to whole-file discovery than silently discover nothing
+			clog.Log.Debugf("    %s: no test functions overlap the PR diff, falling back to whole-file discovery", f.RelPath)
+		}
+	}
+	return f.ExtractTests(splitOn, reappend)
+}
+
 // ExtractChangedTests returns the full (unsplit) names of the acceptance test functions whose declarations overlap
 // the file's PR patch — i.e. only the tests actually modified, not every test in the file. It returns ok=false when
 // the file has no stored patch (it wasn't directly changed in the PR, e.g. discovered via a sibling resource file),

--- a/lib/provider/file-tests.go
+++ b/lib/provider/file-tests.go
@@ -4,10 +4,68 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/katbyte/tctest/lib/clog"
 )
+
+// testFunc is an acceptance test function found in a file, with the line span of its declaration (including any doc
+// comment) so it can be intersected with the changed line ranges of a PR patch.
+type testFunc struct {
+	Name      string
+	StartLine int
+	EndLine   int
+}
+
+// testFuncs parses the file and returns every acceptance test function ("TestAcc" prefix) with its line span.
+// If AST parsing fails it falls back to string matching, in which case line spans cover only the declaration line.
+func (f *File) testFuncs() ([]testFunc, error) {
+	content, err := f.GetContent()
+	if err != nil {
+		return nil, err
+	}
+
+	var tests []testFunc
+	fset := token.NewFileSet()
+
+	parsed, parseErr := parser.ParseFile(fset, f.Path, content, parser.ParseComments)
+	if parseErr != nil {
+		clog.Log.Debugf("    failed to parse %s, falling back to string match: %v", f.RelPath, parseErr)
+		// fallback: scan lines for "func TestAcc" if AST parsing fails
+		for i, line := range strings.Split(string(content), "\n") {
+			if strings.Contains(line, "func TestAcc") {
+				parts := strings.Fields(line)
+				if len(parts) >= 2 {
+					name, _, _ := strings.Cut(parts[1], "(")
+					tests = append(tests, testFunc{Name: name, StartLine: i + 1, EndLine: i + 1})
+				}
+			}
+		}
+		return tests, nil
+	}
+
+	for _, decl := range parsed.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || !strings.HasPrefix(fn.Name.Name, "TestAcc") {
+			continue
+		}
+		clog.Log.Tracef("found test function: %s", fn.Name.Name)
+
+		start := fn.Pos()
+		if fn.Doc != nil {
+			start = fn.Doc.Pos() // a change to the doc comment still touches the test
+		}
+		tests = append(tests, testFunc{
+			Name:      fn.Name.Name,
+			StartLine: fset.Position(start).Line,
+			EndLine:   fset.Position(fn.End()).Line,
+		})
+	}
+
+	return tests, nil
+}
 
 // ExtractTests parses Go source code and extracts names of
 // acceptance tests (functions starting with "TestAcc").
@@ -15,42 +73,17 @@ import (
 // It uses f.GetContent() to read the file (from cached Content or from disk).
 // It also applies the provided `splitOn` and `reappend` logic.
 func (f *File) ExtractTests(splitOn string, reappend bool) ([]string, error) {
-	content, err := f.GetContent()
+	tests, err := f.testFuncs()
 	if err != nil {
 		return nil, err
-	}
-
-	var tests []string
-	fset := token.NewFileSet()
-
-	// Try parsing with AST
-	parsed, parseErr := parser.ParseFile(fset, f.Path, content, 0)
-	if parseErr != nil {
-		clog.Log.Debugf("    failed to parse %s, falling back to string match: %v", f.RelPath, parseErr)
-		// fallback: scan lines for "func TestAcc" if AST parsing fails
-		for line := range strings.SplitSeq(string(content), "\n") {
-			if strings.Contains(line, "func TestAcc") {
-				parts := strings.Fields(line)
-				if len(parts) >= 2 {
-					tests = append(tests, strings.Split(parts[1], "(")[0])
-				}
-			}
-		}
-	} else {
-		for _, decl := range parsed.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if ok && strings.HasPrefix(fn.Name.Name, "TestAcc") {
-				clog.Log.Tracef("found test function: %s", fn.Name.Name)
-				tests = append(tests, fn.Name.Name)
-			}
-		}
 	}
 
 	// process test names: split and optionally reappend split character
 	processedTests := make([]string, 0, len(tests))
 	for _, t := range tests {
 		// split on `(` to make sure we just get the full function name
-		testName := strings.Split(strings.Split(t, splitOn)[0], "(")[0]
+		beforeSplit, _, _ := strings.Cut(t.Name, splitOn)
+		testName, _, _ := strings.Cut(beforeSplit, "(")
 
 		if reappend && splitOn != "" {
 			testName += splitOn
@@ -60,4 +93,58 @@ func (f *File) ExtractTests(splitOn string, reappend bool) ([]string, error) {
 	}
 
 	return processedTests, nil
+}
+
+// hunkHeaderRegex matches unified diff hunk headers like "@@ -12,7 +12,9 @@" and captures the new-side start line and
+// (optional) line count.
+var hunkHeaderRegex = regexp.MustCompile(`(?m)^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
+
+// lineRange is an inclusive range of line numbers on the new side of a diff.
+type lineRange struct {
+	start, end int
+}
+
+// changedLineRanges parses the file's stored patch into the new-side line ranges its hunks cover.
+func (f *File) changedLineRanges() []lineRange {
+	matches := hunkHeaderRegex.FindAllStringSubmatch(f.patch, -1)
+	ranges := make([]lineRange, 0, len(matches))
+	for _, m := range matches {
+		start, _ := strconv.Atoi(m[1])
+		count := 1
+		if m[2] != "" {
+			count, _ = strconv.Atoi(m[2])
+		}
+		if count < 1 {
+			count = 1 // a pure deletion (+N,0) still marks position N as touched
+		}
+		ranges = append(ranges, lineRange{start: start, end: start + count - 1})
+	}
+	return ranges
+}
+
+// ExtractChangedTests returns the full (unsplit) names of the acceptance test functions whose declarations overlap
+// the file's PR patch — i.e. only the tests actually modified, not every test in the file. It returns ok=false when
+// the file has no stored patch (it wasn't directly changed in the PR, e.g. discovered via a sibling resource file),
+// in which case the caller should fall back to ExtractTests' prefix behaviour.
+func (f *File) ExtractChangedTests() (tests []string, ok bool, err error) {
+	changed := f.changedLineRanges()
+	if len(changed) == 0 {
+		return nil, false, nil
+	}
+
+	funcs, err := f.testFuncs()
+	if err != nil {
+		return nil, false, err
+	}
+
+	for _, fn := range funcs {
+		for _, r := range changed {
+			if fn.StartLine <= r.end && r.start <= fn.EndLine {
+				tests = append(tests, fn.Name)
+				break
+			}
+		}
+	}
+
+	return tests, true, nil
 }

--- a/lib/provider/file-tests_test.go
+++ b/lib/provider/file-tests_test.go
@@ -1,0 +1,123 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+const (
+	testNamePrefix = "TestAccAWSInstance"
+	testNameKms    = "TestAccAWSInstance_RootBlockDevice_KmsKeyArn"
+)
+
+const testFileContent = `package example
+
+import "testing"
+
+func TestAccAWSInstance_basic(t *testing.T) {
+	t.Log("basic")
+}
+
+// TestAccAWSInstance_RootBlockDevice_KmsKeyArn tests the kms key arn
+func TestAccAWSInstance_RootBlockDevice_KmsKeyArn(t *testing.T) {
+	t.Log("kms")
+	t.Log("more")
+}
+
+func testAccCheckInstanceExists(t *testing.T) {
+	t.Log("helper")
+}
+
+func TestAccAWSInstance_disappears(t *testing.T) {
+	t.Log("disappears")
+}
+`
+
+func newTestFile(t *testing.T, patch string) *File {
+	t.Helper()
+	f := NewFile("internal/service/ec2/instance_test.go")
+	f.SetContent([]byte(testFileContent))
+	if patch != "" {
+		f.SetPatch(patch)
+	}
+	return &f
+}
+
+func TestExtractTests(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFile(t, "")
+	got, err := f.ExtractTests("_", false)
+	if err != nil {
+		t.Fatalf("ExtractTests() error: %v", err)
+	}
+	want := []string{testNamePrefix, testNamePrefix, testNamePrefix}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractTests() = %v, want %v", got, want)
+	}
+}
+
+func TestExtractChangedTests(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		patch  string
+		want   []string
+		wantOk bool
+	}{
+		"no patch falls back": {
+			patch:  "",
+			want:   nil,
+			wantOk: false,
+		},
+		"change inside one test": {
+			// lines 10-11 are inside TestAccAWSInstance_RootBlockDevice_KmsKeyArn (doc comment starts line 9)
+			patch:  "@@ -10,2 +10,2 @@\n-	t.Log(\"kms\")\n+	t.Log(\"kms!\")",
+			want:   []string{testNameKms},
+			wantOk: true,
+		},
+		"change to doc comment counts": {
+			patch:  "@@ -9,1 +9,1 @@",
+			want:   []string{testNameKms},
+			wantOk: true,
+		},
+		"changes across two tests": {
+			patch:  "@@ -5,3 +5,3 @@\n@@ -19,2 +19,2 @@",
+			want:   []string{"TestAccAWSInstance_basic", "TestAccAWSInstance_disappears"},
+			wantOk: true,
+		},
+		"change only to non-test helper": {
+			patch:  "@@ -15,3 +15,3 @@",
+			want:   nil,
+			wantOk: true,
+		},
+		"hunk with no count (single line)": {
+			patch:  "@@ -6 +6 @@",
+			want:   []string{"TestAccAWSInstance_basic"},
+			wantOk: true,
+		},
+		"pure deletion still marks position": {
+			patch:  "@@ -12,1 +12,0 @@",
+			want:   []string{testNameKms},
+			wantOk: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFile(t, tc.patch)
+			got, ok, err := f.ExtractChangedTests()
+			if err != nil {
+				t.Fatalf("ExtractChangedTests() error: %v", err)
+			}
+			if ok != tc.wantOk {
+				t.Fatalf("ExtractChangedTests() ok = %v, want %v", ok, tc.wantOk)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ExtractChangedTests() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/lib/provider/file-tests_test.go
+++ b/lib/provider/file-tests_test.go
@@ -121,3 +121,49 @@ func TestExtractChangedTests(t *testing.T) {
 		})
 	}
 }
+
+func TestDiscoverTests(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		patch      string
+		individual bool
+		want       []string
+	}{
+		"individual off splits to prefixes": {
+			patch:      "@@ -10,2 +10,2 @@",
+			individual: false,
+			want:       []string{testNamePrefix, testNamePrefix, testNamePrefix},
+		},
+		"individual with patch yields modified full names": {
+			patch:      "@@ -10,2 +10,2 @@",
+			individual: true,
+			want:       []string{testNameComplete},
+		},
+		"individual without patch falls back to prefixes": {
+			patch:      "",
+			individual: true,
+			want:       []string{testNamePrefix, testNamePrefix, testNamePrefix},
+		},
+		"individual with helper-only diff falls back to prefixes": {
+			patch:      "@@ -15,3 +15,3 @@",
+			individual: true,
+			want:       []string{testNamePrefix, testNamePrefix, testNamePrefix},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFile(t, tc.patch)
+			got, err := f.DiscoverTests("_", false, tc.individual)
+			if err != nil {
+				t.Fatalf("DiscoverTests() error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("DiscoverTests() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/lib/provider/file-tests_test.go
+++ b/lib/provider/file-tests_test.go
@@ -7,7 +7,9 @@ import (
 
 const (
 	testNamePrefix   = "TestAccPostgresqlFlexibleServer"
+	testNameBasic    = "TestAccPostgresqlFlexibleServer_basic"
 	testNameComplete = "TestAccPostgresqlFlexibleServer_complete"
+	testNameImport   = "TestAccPostgresqlFlexibleServer_requiresImport"
 )
 
 const testFileContent = `package example
@@ -83,7 +85,7 @@ func TestExtractChangedTests(t *testing.T) {
 		},
 		"changes across two tests": {
 			patch:  "@@ -5,3 +5,3 @@\n@@ -19,2 +19,2 @@",
-			want:   []string{"TestAccPostgresqlFlexibleServer_basic", "TestAccPostgresqlFlexibleServer_requiresImport"},
+			want:   []string{testNameBasic, testNameImport},
 			wantOk: true,
 		},
 		"change only to non-test helper": {
@@ -93,7 +95,7 @@ func TestExtractChangedTests(t *testing.T) {
 		},
 		"hunk with no count (single line)": {
 			patch:  "@@ -6 +6 @@",
-			want:   []string{"TestAccPostgresqlFlexibleServer_basic"},
+			want:   []string{testNameBasic},
 			wantOk: true,
 		},
 		"pure deletion still marks position": {
@@ -143,12 +145,12 @@ func TestDiscoverTests(t *testing.T) {
 		"individual without patch lists all full names": {
 			patch:      "",
 			individual: true,
-			want:       []string{"TestAccPostgresqlFlexibleServer_basic", testNameComplete, "TestAccPostgresqlFlexibleServer_requiresImport"},
+			want:       []string{testNameBasic, testNameComplete, testNameImport},
 		},
 		"individual with helper-only diff lists all full names": {
 			patch:      "@@ -15,3 +15,3 @@",
 			individual: true,
-			want:       []string{"TestAccPostgresqlFlexibleServer_basic", testNameComplete, "TestAccPostgresqlFlexibleServer_requiresImport"},
+			want:       []string{testNameBasic, testNameComplete, testNameImport},
 		},
 	}
 

--- a/lib/provider/file-tests_test.go
+++ b/lib/provider/file-tests_test.go
@@ -140,15 +140,15 @@ func TestDiscoverTests(t *testing.T) {
 			individual: true,
 			want:       []string{testNameComplete},
 		},
-		"individual without patch falls back to prefixes": {
+		"individual without patch lists all full names": {
 			patch:      "",
 			individual: true,
-			want:       []string{testNamePrefix, testNamePrefix, testNamePrefix},
+			want:       []string{"TestAccPostgresqlFlexibleServer_basic", testNameComplete, "TestAccPostgresqlFlexibleServer_requiresImport"},
 		},
-		"individual with helper-only diff falls back to prefixes": {
+		"individual with helper-only diff lists all full names": {
 			patch:      "@@ -15,3 +15,3 @@",
 			individual: true,
-			want:       []string{testNamePrefix, testNamePrefix, testNamePrefix},
+			want:       []string{"TestAccPostgresqlFlexibleServer_basic", testNameComplete, "TestAccPostgresqlFlexibleServer_requiresImport"},
 		},
 	}
 

--- a/lib/provider/file-tests_test.go
+++ b/lib/provider/file-tests_test.go
@@ -6,36 +6,36 @@ import (
 )
 
 const (
-	testNamePrefix = "TestAccAWSInstance"
-	testNameKms    = "TestAccAWSInstance_RootBlockDevice_KmsKeyArn"
+	testNamePrefix   = "TestAccPostgresqlFlexibleServer"
+	testNameComplete = "TestAccPostgresqlFlexibleServer_complete"
 )
 
 const testFileContent = `package example
 
 import "testing"
 
-func TestAccAWSInstance_basic(t *testing.T) {
+func TestAccPostgresqlFlexibleServer_basic(t *testing.T) {
 	t.Log("basic")
 }
 
-// TestAccAWSInstance_RootBlockDevice_KmsKeyArn tests the kms key arn
-func TestAccAWSInstance_RootBlockDevice_KmsKeyArn(t *testing.T) {
-	t.Log("kms")
+// TestAccPostgresqlFlexibleServer_complete tests the complete configuration
+func TestAccPostgresqlFlexibleServer_complete(t *testing.T) {
+	t.Log("complete")
 	t.Log("more")
 }
 
-func testAccCheckInstanceExists(t *testing.T) {
+func testAccCheckPostgresqlFlexibleServerExists(t *testing.T) {
 	t.Log("helper")
 }
 
-func TestAccAWSInstance_disappears(t *testing.T) {
-	t.Log("disappears")
+func TestAccPostgresqlFlexibleServer_requiresImport(t *testing.T) {
+	t.Log("import")
 }
 `
 
 func newTestFile(t *testing.T, patch string) *File {
 	t.Helper()
-	f := NewFile("internal/service/ec2/instance_test.go")
+	f := NewFile("internal/services/postgres/postgresql_flexible_server_resource_test.go")
 	f.SetContent([]byte(testFileContent))
 	if patch != "" {
 		f.SetPatch(patch)
@@ -71,19 +71,19 @@ func TestExtractChangedTests(t *testing.T) {
 			wantOk: false,
 		},
 		"change inside one test": {
-			// lines 10-11 are inside TestAccAWSInstance_RootBlockDevice_KmsKeyArn (doc comment starts line 9)
+			// lines 10-11 are inside TestAccPostgresqlFlexibleServer_complete (doc comment starts line 9)
 			patch:  "@@ -10,2 +10,2 @@\n-	t.Log(\"kms\")\n+	t.Log(\"kms!\")",
-			want:   []string{testNameKms},
+			want:   []string{testNameComplete},
 			wantOk: true,
 		},
 		"change to doc comment counts": {
 			patch:  "@@ -9,1 +9,1 @@",
-			want:   []string{testNameKms},
+			want:   []string{testNameComplete},
 			wantOk: true,
 		},
 		"changes across two tests": {
 			patch:  "@@ -5,3 +5,3 @@\n@@ -19,2 +19,2 @@",
-			want:   []string{"TestAccAWSInstance_basic", "TestAccAWSInstance_disappears"},
+			want:   []string{"TestAccPostgresqlFlexibleServer_basic", "TestAccPostgresqlFlexibleServer_requiresImport"},
 			wantOk: true,
 		},
 		"change only to non-test helper": {
@@ -93,12 +93,12 @@ func TestExtractChangedTests(t *testing.T) {
 		},
 		"hunk with no count (single line)": {
 			patch:  "@@ -6 +6 @@",
-			want:   []string{"TestAccAWSInstance_basic"},
+			want:   []string{"TestAccPostgresqlFlexibleServer_basic"},
 			wantOk: true,
 		},
 		"pure deletion still marks position": {
 			patch:  "@@ -12,1 +12,0 @@",
-			want:   []string{testNameKms},
+			want:   []string{testNameComplete},
 			wantOk: true,
 		},
 	}

--- a/lib/provider/file.go
+++ b/lib/provider/file.go
@@ -28,6 +28,7 @@ type File struct {
 	Type         FileType
 	DiscoveredBy []string // e.g. CHANGED, DERIVED, TRACED, VENDOR
 	content      []byte   // optional file content for self-reading methods
+	patch        string   // unified diff for directly changed files (from the GitHub PR file listing), used for individual test discovery
 }
 
 // NewFileWithPath creates a File from a relative path and a local repository root.
@@ -93,6 +94,12 @@ func (f *File) GetContent() ([]byte, error) {
 func (f *File) SetContent(content []byte) {
 	f.content = content
 	f.Classify()
+}
+
+// SetPatch stores the file's unified diff from the GitHub PR file listing, enabling individual test discovery
+// (ExtractChangedTests) for directly changed test files.
+func (f *File) SetPatch(patch string) {
+	f.patch = patch
 }
 
 // InServicePackage returns true if the path is within a service directory.


### PR DESCRIPTION
Closes #38

Implements the `-i` flag from the issue:

```
% tctest list -i 194782
Discovering tests for pr #194782 ...
    TestAccPostgresqlFlexibleServer_complete
```

**How it works:** the GitHub PR file listing already includes each file's unified diff, so directly changed test files keep their patch. At extraction time, the hunk header line ranges are intersected with the parsed `TestAcc` function spans (doc comments included), and only the overlapping tests are discovered — by full name.

**With `-i`, prefixes are never used** — the intent is individual tests throughout, never a mix:
- A directly changed test file yields only the test functions the PR modifies.
- A test file discovered *indirectly* (changed resource file → sibling test files, helper import tracing) yields **every** test function it contains, by full name — any of them could be affected by the change, so the whole set runs, just explicitly named.
- A changed test file whose diff touches only non-test code (e.g. a shared check helper) likewise falls back to all of its tests by full name rather than silently discovering nothing.

Without `-i`, behaviour is unchanged (split-prefix discovery).

Works in both API and AST modes and applies to `list`, `pr`, and `prs` (discovery is shared, via `provider.File.DiscoverTests` in lib). Env var: `TCTEST_INDIVIDUAL`.

Includes unit tests for the hunk-range/function-span intersection and fallback rules, plus end-to-end integration cases in both modes for the changed-test-file and changed-resource-file paths (the mock GitHub now serves per-file patches).

Note: patch line numbers come from the PR diff while AST mode reads content at the merge commit; if main concurrently modified the same file the ranges can drift slightly — acceptable for discovery purposes.