### PR TITLE
send service package name as a build property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.2.0 (unreleased)
 
+- send the discovered service package name as a TeamCity build property, `SERVICE_PACKAGE` by default; rename it with `--properties-service-package`/`TCTEST_PROPERTIES_SERVICE_PACKAGE` or set it empty to not send it ([#116](https://github.com/katbyte/tctest/pull/116))
 - add `--force`/`-f` flag to bypass the `--max-builds-per-pr` check ([#107](https://github.com/katbyte/tctest/pull/107))
 - include the build type id and TeamCity's error response in the "unable to trigger build" error instead of just the HTTP status code ([#107](https://github.com/katbyte/tctest/pull/107))
 - discover AzureRM tests when state migration files (`{service}/migration/{resource_name}_v{N}_to_v{N}.go`) are modified in API mode ([#105](https://github.com/katbyte/tctest/pull/105))

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Create a file like [`set_env_example.sh`](.github/images/set_env_example.sh) and
 | `TCTEST_USER` | `--username` | TeamCity username (alternative to token) |
 | `TCTEST_PASS` | `--password` | TeamCity password (alternative to token) |
 | `TCTEST_PROPERTIES` | `--properties`, `-p` | Default build parameters in `KEY=VALUE;KEY2=VALUE2` format |
+| `TCTEST_PROPERTIES_SERVICE_PACKAGE` | `--properties-service-package` | Build property name to send the discovered service package name as (default: `SERVICE_PACKAGE`) |
 | `GITHUB_TOKEN` | `--token-gh` | GitHub OAuth token |
 | `TCTEST_REPO` | `--repo`, `-r` | GitHub repository (e.g. `hashicorp/terraform-provider-azurerm`) |
 | `TCTEST_FILEREGEX` | `--fileregex` | Regex to filter PR files for test discovery |
@@ -260,6 +261,7 @@ These flags apply to any command that triggers a build:
 | Flag | Short | Description |
 |---|---|---|
 | `--properties` | `-p` | Build parameters in `KEY=VALUE;KEY2=VALUE2` format |
+| `--properties-service-package` | | Build property name to send the discovered service package name as (default: `SERVICE_PACKAGE`; set empty via the flag or config file to not send it) |
 | `--comment` | `-c` | Post a GitHub comment with test results (`POST_GITHUB_COMMENT=true`) |
 | `--skip-queue` | `-q` | Put the build to the top of the queue |
 | `--wait` | `-w` | Wait for the build to complete before exiting |

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -133,19 +133,20 @@ type FlagsTeamCity struct {
 }
 
 type FlagsTeamCityBuild struct {
-	TypeID           string   `mapstructure:"build-type-id"`
-	LegacyTypeID     string   `mapstructure:"buildtypeid"`
-	Parameters       string   `mapstructure:"properties"`
-	SkipQueue        bool     `mapstructure:"skip-queue"`
-	Wait             bool     `mapstructure:"wait"`
-	Latest           bool     `mapstructure:"latest"`
-	Comment          bool     `mapstructure:"comment"`
-	ForceOldUI       bool     `mapstructure:"build-link-force-old-ui"`
-	AddServiceSuffix bool     `mapstructure:"build-type-id-add-service-suffix"`
-	QueueTimeout     int      `mapstructure:"queue-timeout"`
-	RunTimeout       int      `mapstructure:"run-timeout"`
-	MaxBuildsPerPR   int      `mapstructure:"max-builds-per-pr"`
-	Tags             []string `mapstructure:"tag"`
+	TypeID                 string   `mapstructure:"build-type-id"`
+	LegacyTypeID           string   `mapstructure:"buildtypeid"`
+	Parameters             string   `mapstructure:"properties"`
+	SkipQueue              bool     `mapstructure:"skip-queue"`
+	Wait                   bool     `mapstructure:"wait"`
+	Latest                 bool     `mapstructure:"latest"`
+	Comment                bool     `mapstructure:"comment"`
+	ForceOldUI             bool     `mapstructure:"build-link-force-old-ui"`
+	AddServiceSuffix       bool     `mapstructure:"build-type-id-add-service-suffix"`
+	ServicePackageProperty string   `mapstructure:"properties-service-package"`
+	QueueTimeout           int      `mapstructure:"queue-timeout"`
+	RunTimeout             int      `mapstructure:"run-timeout"`
+	MaxBuildsPerPR         int      `mapstructure:"max-builds-per-pr"`
+	Tags                   []string `mapstructure:"tag"`
 }
 
 func configureFlags(root *cobra.Command) error {
@@ -219,6 +220,7 @@ func configureFlags(root *cobra.Command) error {
 	pflags.String("build-type-id", "", "the TeamCity BuildTypeId to trigger")
 	pflags.Bool("build-type-id-add-service-suffix", false, "append _SERVICE to the build type ID for per-service build configurations (previously appended automatically by --buildtypeid)")
 	pflags.StringP("properties", "p", "", "the TeamCity build parameters to use in 'KEY1=VALUE1;KEY2=VALUE2' format")
+	pflags.String("properties-service-package", "SERVICE_PACKAGE", "build property name to send the discovered service package name as (set empty to not send it)")
 	pflags.BoolP("skip-queue", "q", false, "Put the build to the queue top")
 	pflags.BoolP("wait", "w", false, "Wait for the build to complete before tctest exits")
 	pflags.BoolP("latest", "", false, "gets the latest build in TeamCity")
@@ -242,6 +244,7 @@ func configureFlags(root *cobra.Command) error {
 		"username":                         "TCTEST_USER",
 		"password":                         "TCTEST_PASS",
 		"properties":                       "TCTEST_PROPERTIES",
+		"properties-service-package":       "TCTEST_PROPERTIES_SERVICE_PACKAGE",
 		"repo":                             "TCTEST_REPO",
 		"fileregex":                        "TCTEST_FILEREGEX",
 		"acctest-file-suffix-regexes":      "TCTEST_ACCTEST_FILE_SUFFIX_REGEXES",

--- a/cli/prs.go
+++ b/cli/prs.go
@@ -214,11 +214,6 @@ func (f *FlagData) resolveServiceFilter() (*serviceFilterResult, error) {
 
 // triggerServiceBuild triggers a build for a single service on a PR
 func (f *FlagData) triggerServiceBuild(service string, prNumber int, testRegEx string) error {
-	serviceInfo := ""
-	if service != "" {
-		serviceInfo = "[" + service + "]"
-	}
-
 	buildTypeID := f.TC.Build.TypeID
 	if service != "" && f.TC.Build.AddServiceSuffix {
 		buildTypeID += "_" + strings.ToUpper(service)
@@ -226,7 +221,7 @@ func (f *FlagData) triggerServiceBuild(service string, prNumber int, testRegEx s
 
 	branch := fmt.Sprintf("refs/pull/%d/merge", prNumber)
 
-	buildID, buildURL, err := f.BuildCmd(buildTypeID, branch, testRegEx, serviceInfo)
+	buildID, buildURL, err := f.BuildCmd(buildTypeID, branch, testRegEx, service)
 	if err != nil {
 		cout.Errorf("  <red>ERROR: Unable to trigger build:</> %v\n", err)
 		cout.Println()

--- a/cli/tc.go
+++ b/cli/tc.go
@@ -11,10 +11,17 @@ import (
 	"github.com/pkg/browser"
 )
 
+// BuildCmd triggers a TeamCity build. service is the raw service package name ("" when not building per-service);
+// it is used for display and, when --properties-service-package is set, sent as a build property under that name.
 func (f *FlagData) BuildCmd(buildTypeID, branch, testRegex, service string) (buildID int, buildURL string, err error) {
 	tc := f.NewTCServer()
 
-	cout.Printf("triggering <magenta>%s</>%s @ <darkGray>%s...</>\n", branch, service, buildTypeID)
+	serviceInfo := ""
+	if service != "" {
+		serviceInfo = "[" + service + "]"
+	}
+
+	cout.Printf("triggering <magenta>%s</>%s @ <darkGray>%s...</>\n", branch, serviceInfo, buildTypeID)
 
 	properties := f.TC.Build.Parameters
 	if f.TC.Build.Comment {
@@ -22,6 +29,17 @@ func (f *FlagData) BuildCmd(buildTypeID, branch, testRegex, service string) (bui
 			properties += ";"
 		}
 		properties += "POST_GITHUB_COMMENT=true"
+	}
+
+	if name := f.TC.Build.ServicePackageProperty; name != "" && service != "" {
+		// the properties string is parsed on ';' and '=', so either character in the name would corrupt it
+		if strings.ContainsAny(name, ";=") {
+			return 0, "", fmt.Errorf("invalid --properties-service-package property name %q: must not contain ';' or '='", name)
+		}
+		if properties != "" {
+			properties += ";"
+		}
+		properties += name + "=" + service
 	}
 
 	if f.DryRun {

--- a/integration/integration_azurerm_test.go
+++ b/integration/integration_azurerm_test.go
@@ -445,3 +445,80 @@ func TestPrsCommand(t *testing.T) {
 		})
 	}
 }
+
+// TestServicePackageProperty covers --properties-service-package / TCTEST_PROPERTIES_SERVICE_PACKAGE: the discovered
+// service package name is sent as a build property, named SERVICE_PACKAGE by default, renameable, and disableable
+// with an empty value (via the flag; an empty env var falls back to the default as viper treats it as unset).
+func TestServicePackageProperty(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default sends SERVICE_PACKAGE per service", func(t *testing.T) {
+		t.Parallel()
+		scenario(t, "api/azurerm", "properties-service-package default")
+		gh := newMockGitHub(t, "testdata/azurerm", azurermPRs)
+		tc := newMockTeamCity(t)
+
+		res := runTCTest(t, azurermEnv(gh, tc), "pr", "1004")
+		if res.exitCode != 0 {
+			t.Fatalf("exit code = %d, want 0\noutput:\n%s", res.exitCode, res.output)
+		}
+
+		props := tc.Properties()
+		if len(props) != 2 {
+			t.Fatalf("expected 2 triggered builds, got %d\noutput:\n%s", len(props), res.output)
+		}
+		got := map[string]bool{}
+		for _, p := range props {
+			got[p["SERVICE_PACKAGE"]] = true
+		}
+		if !got["postgres"] || !got["dns"] {
+			t.Fatalf("expected SERVICE_PACKAGE properties for postgres and dns, got %v\noutput:\n%s", got, res.output)
+		}
+	})
+
+	t.Run("env renames the property", func(t *testing.T) {
+		t.Parallel()
+		scenario(t, "api/azurerm", "properties-service-package renamed")
+		gh := newMockGitHub(t, "testdata/azurerm", azurermPRs)
+		tc := newMockTeamCity(t)
+
+		env := azurermEnv(gh, tc)
+		env["TCTEST_PROPERTIES_SERVICE_PACKAGE"] = "PKG"
+
+		res := runTCTest(t, env, "pr", "1001")
+		if res.exitCode != 0 {
+			t.Fatalf("exit code = %d, want 0\noutput:\n%s", res.exitCode, res.output)
+		}
+
+		props := tc.Properties()
+		if len(props) != 1 {
+			t.Fatalf("expected 1 triggered build, got %d\noutput:\n%s", len(props), res.output)
+		}
+		if got := props[0]["PKG"]; got != "postgres" {
+			t.Fatalf("expected PKG=postgres, got %q\noutput:\n%s", got, res.output)
+		}
+		if v, ok := props[0]["SERVICE_PACKAGE"]; ok {
+			t.Fatalf("expected no SERVICE_PACKAGE property when renamed, got %q\noutput:\n%s", v, res.output)
+		}
+	})
+
+	t.Run("empty flag disables the property", func(t *testing.T) {
+		t.Parallel()
+		scenario(t, "api/azurerm", "properties-service-package disabled")
+		gh := newMockGitHub(t, "testdata/azurerm", azurermPRs)
+		tc := newMockTeamCity(t)
+
+		res := runTCTest(t, azurermEnv(gh, tc), "pr", "1001", "--properties-service-package", "")
+		if res.exitCode != 0 {
+			t.Fatalf("exit code = %d, want 0\noutput:\n%s", res.exitCode, res.output)
+		}
+
+		props := tc.Properties()
+		if len(props) != 1 {
+			t.Fatalf("expected 1 triggered build, got %d\noutput:\n%s", len(props), res.output)
+		}
+		if v, ok := props[0]["SERVICE_PACKAGE"]; ok {
+			t.Fatalf("expected no SERVICE_PACKAGE property, got %q\noutput:\n%s", v, res.output)
+		}
+	})
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -324,6 +324,7 @@ type mockTeamCity struct {
 
 	mu       sync.Mutex
 	triggers []trigger
+	props    []map[string]string // all properties of each trigger, parallel to triggers
 	nextID   int
 }
 
@@ -376,6 +377,7 @@ func (m *mockTeamCity) handle(w http.ResponseWriter, r *http.Request) {
 		Branch:      props["teamcity.build.branch"],
 		TestPattern: props["TEST_PATTERN"],
 	})
+	m.props = append(m.props, props)
 	m.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/xml")
@@ -387,6 +389,15 @@ func (m *mockTeamCity) Triggers() []trigger {
 	defer m.mu.Unlock()
 	out := make([]trigger, len(m.triggers))
 	copy(out, m.triggers)
+	return out
+}
+
+// Properties returns the full property set of each triggered build, in trigger order.
+func (m *mockTeamCity) Properties() []map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]map[string]string, len(m.props))
+	copy(out, m.props)
 	return out
 }
 


### PR DESCRIPTION
Sends the discovered service package name as a TeamCity build property, `SERVICE_PACKAGE` by default. Rename it with `--properties-service-package`/`TCTEST_PROPERTIES_SERVICE_PACKAGE` (e.g. `PKG`) or set it empty to not send it.