### PR TITLE
Make TeamCity API version configurable via --api-version / TCTEST_API_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Create a file like [`set_env_example.sh`](.github/images/set_env_example.sh) and
 | Variable | Flag | Description |
 |---|---|---|
 | `TCTEST_SERVER` | `--server`, `-s` | TeamCity server URL |
+| `TCTEST_API_VERSION` | `--api-version` | TeamCity REST API version used in request paths (default: `2026.1`) |
 | `TCTEST_BUILD_TYPE_ID` | `--build-type-id`, `-b` | TeamCity build configuration ID |
 | `TCTEST_TOKEN_TC` | `--token-tc`, `-t` | TeamCity authentication token |
 | `TCTEST_USER` | `--username` | TeamCity username (alternative to token) |

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -126,11 +126,12 @@ type FlagsGitHubPrFilter struct {
 }
 
 type FlagsTeamCity struct {
-	Build     FlagsTeamCityBuild `mapstructure:",squash"`
-	ServerURL string             `mapstructure:"server"`
-	Token     string             `mapstructure:"token-tc"`
-	User      string             `mapstructure:"username"`
-	Pass      string             `mapstructure:"password"`
+	Build      FlagsTeamCityBuild `mapstructure:",squash"`
+	ServerURL  string             `mapstructure:"server"`
+	APIVersion string             `mapstructure:"api-version"`
+	Token      string             `mapstructure:"token-tc"`
+	User       string             `mapstructure:"username"`
+	Pass       string             `mapstructure:"password"`
 }
 
 type FlagsTeamCityBuild struct {
@@ -213,6 +214,7 @@ func configureFlags(root *cobra.Command) error {
 
 	// TeamCity Flags (FlagsTeamCity)
 	pflags.StringP("server", "s", "", "the TeamCity server's url")
+	pflags.String("api-version", tc.DefaultAPIVersion, "the TeamCity REST API version to use in request paths")
 	pflags.StringP("token-tc", "t", "", "the TeamCity token to use (consider exporting token to TCTEST_TOKEN_TC instead)")
 	pflags.String("username", "", "the TeamCity user to use")
 	pflags.String("password", "", "the TeamCity password to use (consider exporting pass to TCTEST_PASS instead)")
@@ -236,6 +238,7 @@ func configureFlags(root *cobra.Command) error {
 	// binding map for viper/pflag -> env
 	m := map[string]string{ //nolint:gosec // G101: these are env var names, not credentials
 		"server":                           "TCTEST_SERVER",
+		"api-version":                      "TCTEST_API_VERSION",
 		"buildtypeid":                      "TCTEST_BUILDTYPEID",
 		"build-type-id":                    "TCTEST_BUILD_TYPE_ID",
 		"build-type-id-add-service-suffix": "TCTEST_BUILD_TYPE_ID_ADD_SERVICE_SUFFIX",
@@ -358,5 +361,7 @@ func (cfg DiscoveryConfig) AccTestFileSuffixRegexStrings() string {
 }
 
 func (f *FlagData) NewTCServer() tc.Server {
-	return tc.NewServer(f.TC.ServerURL, f.TC.Token, f.TC.User, f.TC.Pass)
+	s := tc.NewServer(f.TC.ServerURL, f.TC.Token, f.TC.User, f.TC.Pass)
+	s.APIVersion = f.TC.APIVersion
+	return s
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -348,7 +348,7 @@ func newMockTeamCity(t *testing.T) *mockTeamCity {
 }
 
 func (m *mockTeamCity) handle(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost || r.URL.Path != "/app/rest/"+tc.TeamCityAPIVersion+"/buildQueue" {
+	if r.Method != http.MethodPost || r.URL.Path != "/app/rest/"+tc.DefaultAPIVersion+"/buildQueue" {
 		http.NotFound(w, r)
 		return
 	}

--- a/lib/tc/build.go
+++ b/lib/tc/build.go
@@ -79,7 +79,7 @@ func (s Server) TriggerBuild(buildTypeID, branch, testPattern, buildProperties s
 </build>
 `, xmlEscape(buildTypeID), xmlEscape(branch), xmlEscape(testPattern), bodyAdditionalProperties, strconv.FormatBool(skipQueue))
 
-	return s.makePostRequestWithXMLContentType("/app/rest/"+TeamCityAPIVersion+"/buildQueue", body)
+	return s.makePostRequestWithXMLContentType("/app/rest/"+s.apiVersion()+"/buildQueue", body)
 }
 
 // condenseBody flattens a TeamCity error response body onto a single line so it can be included in an error message;
@@ -107,11 +107,11 @@ func (s Server) BuildLog(buildID int) (statusCode int, body string, err error) {
 }
 
 func (s Server) BuildQueue(buildID int) (statusCode int, body string, err error) {
-	return s.makeGetRequest(fmt.Sprintf("/app/rest/%s/buildQueue/id:%d", TeamCityAPIVersion, buildID))
+	return s.makeGetRequest(fmt.Sprintf("/app/rest/%s/buildQueue/id:%d", s.apiVersion(), buildID))
 }
 
 func (s Server) BuildState(buildID int) (statusCode int, body string, err error) {
-	return s.makeGetRequest(fmt.Sprintf("/app/rest/%s/builds/%d/state", TeamCityAPIVersion, buildID))
+	return s.makeGetRequest(fmt.Sprintf("/app/rest/%s/builds/%d/state", s.apiVersion(), buildID))
 }
 
 func (s Server) WaitForBuild(buildID, queueTimeout, runTimeout int) error {
@@ -168,7 +168,7 @@ type finishedBuildResp struct {
 // TeamCity's cancellation reason when it provides one. Cancelled builds carry a canceledInfo element and status
 // UNKNOWN, either of which is treated as cancellation.
 func (s Server) CheckFinishedBuild(buildID int) error {
-	statusCode, body, err := s.makeGetRequest(fmt.Sprintf("/app/rest/%s/builds/%d", TeamCityAPIVersion, buildID))
+	statusCode, body, err := s.makeGetRequest(fmt.Sprintf("/app/rest/%s/builds/%d", s.apiVersion(), buildID))
 	if err != nil {
 		return fmt.Errorf("error fetching status for build %d: %w", buildID, err)
 	}
@@ -236,7 +236,7 @@ func (s Server) AddTags(buildID int, tags []string) error {
 		}
 
 		// TeamCity REST API expects a simple text body for adding tags
-		statusCode, _, err := s.makePostRequestWithContentType(fmt.Sprintf("/app/rest/%s/builds/id:%d/tags", TeamCityAPIVersion, buildID), tag, "text/plain")
+		statusCode, _, err := s.makePostRequestWithContentType(fmt.Sprintf("/app/rest/%s/builds/id:%d/tags", s.apiVersion(), buildID), tag, "text/plain")
 		if err != nil {
 			return fmt.Errorf("error adding tag '%s' to build %d: %w", tag, buildID, err)
 		}

--- a/lib/tc/build_test.go
+++ b/lib/tc/build_test.go
@@ -60,7 +60,7 @@ func TestCheckFinishedBuild(t *testing.T) {
 			t.Parallel()
 
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/app/rest/"+TeamCityAPIVersion+"/builds/123" {
+				if r.URL.Path != "/app/rest/"+DefaultAPIVersion+"/builds/123" {
 					http.NotFound(w, r)
 					return
 				}

--- a/lib/tc/builds.go
+++ b/lib/tc/builds.go
@@ -36,7 +36,7 @@ func (s Server) GetBuildsForPR(buildTypeID string, pr int, latest, wait bool, qu
 		queryArgs += ",count:1"
 	}
 
-	statusCode, body, err := s.makeGetRequest("/app/rest/" + TeamCityAPIVersion + "/builds?locator=" + queryArgs)
+	statusCode, body, err := s.makeGetRequest("/app/rest/" + s.apiVersion() + "/builds?locator=" + queryArgs)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list builds (%s): %w", queryArgs, err)
 	}

--- a/lib/tc/tc.go
+++ b/lib/tc/tc.go
@@ -5,13 +5,23 @@ import (
 	"github.com/katbyte/tctest/lib/clog"
 )
 
-const TeamCityAPIVersion = "2026.1"
+// DefaultAPIVersion is the TeamCity REST API version used in request paths when Server.APIVersion is not set.
+const DefaultAPIVersion = "2026.1"
 
 type Server struct {
-	Server string
-	token  *string
-	User   *string
-	Pass   *string
+	Server     string
+	APIVersion string
+	token      *string
+	User       *string
+	Pass       *string
+}
+
+// apiVersion returns the REST API version segment for request paths, falling back to DefaultAPIVersion when unset.
+func (s Server) apiVersion() string {
+	if s.APIVersion != "" {
+		return s.APIVersion
+	}
+	return DefaultAPIVersion
 }
 
 func NewServer(server, token, username, password string) Server {


### PR DESCRIPTION
Follows up on #119: instead of a hardcoded constant, the TeamCity REST API version used in request paths is now configurable.

- New `--api-version` flag and `TCTEST_API_VERSION` env var (also settable via `.tctest` config), defaulting to `2026.1` as before
- `tc.Server` gains an `APIVersion` field; the old `TeamCityAPIVersion` constant is renamed to `DefaultAPIVersion` and used as the fallback when the field is unset, so direct library users are unaffected
- All request paths in `lib/tc` now use the server's configured version
- Documented the new env var in the README

Build, vet, unit tests, and the integration suite all pass; `--api-version` shows in help with the correct default.