### PR TITLE
ci: fix codeql go extraction

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,8 +32,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        include:
+        - language: go
+          build-mode: none
+        - language: actions
+          build-mode: none
+        # CodeQL also supports cpp, csharp, java, javascript, python, ruby, swift, kotlin
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
@@ -45,22 +49,13 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
         queries: security-extended,security-and-quality
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+        config: |
+          paths-ignore:
+            - vendor
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         include:
         - language: go
-          build-mode: none
+          build-mode: autobuild
         - language: actions
           build-mode: none
         # CodeQL also supports cpp, csharp, java, javascript, python, ruby, swift, kotlin

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 [![GitHub release](https://img.shields.io/github/v/release/katbyte/tctest?color=blueviolet)](https://github.com/katbyte/tctest/releases/latest)
 ![build](https://github.com/katbyte/tctest/actions/workflows/build.yaml/badge.svg)
+![test](https://github.com/katbyte/tctest/actions/workflows/test.yaml/badge.svg)
 ![lint](https://github.com/katbyte/tctest/actions/workflows/lint.yaml/badge.svg)
-[![Go Report Card](https://goreportcard.com/badge/github.com/katbyte/tctest)](https://goreportcard.com/report/github.com/katbyte/tctest)
+![govulncheck](https://github.com/katbyte/tctest/actions/workflows/govulncheck.yaml/badge.svg)
+![CodeQL](https://github.com/katbyte/tctest/actions/workflows/codeql-analysis.yml/badge.svg)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/katbyte/tctest?color=00ADD8)](https://github.com/katbyte/tctest/blob/main/go.mod)
 [![License](https://img.shields.io/github/license/katbyte/tctest?color=blue)](https://github.com/katbyte/tctest/blob/main/LICENSE)
 
 A command-line utility to trigger builds in TeamCity to run provider acceptance tests. Given a PR number it can find the files modified, discover the tests to run, and generate a `TEST_PATTERN` automatically.    


### PR DESCRIPTION
Switch Go to `build-mode: none` and ignore `integration/testdata` — autobuild fails on the unbuildable fixture modules there.