### PR TITLE
ci: sign releases and attach build provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # goreleaser uploads the release and its assets
+      id-token: write # cosign keyless signing and attestation signing via OIDC
+      attestations: write # actions/attest-build-provenance stores attestations
+    outputs:
+      hashes: ${{ steps.hashes.outputs.hashes }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -19,12 +23,31 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: ./.go-version
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: export artifact hashes for slsa provenance
+        id: hashes
+        run: echo "hashes=$(base64 -w0 < ./dist/checksums.txt)" >> "$GITHUB_OUTPUT"
+      - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-checksums: ./dist/checksums.txt # attest every artifact goreleaser published
+
+  provenance:
+    needs: goreleaser
+    permissions:
+      actions: read # read the workflow run to record the build context
+      id-token: write # sign the provenance
+      contents: write # upload multiple.intoto.jsonl to the release
+    # the slsa builder must be referenced by tag, not commit hash; it verifies its own ref at runtime
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.goreleaser.outputs.hashes }}
+      upload-assets: true
 
   homebrew:
     needs: goreleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,6 +67,19 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 
+signs:
+  - cmd: cosign
+    artifacts: checksum # signing checksums.txt covers every artifact it lists
+    signature: '${artifact}.sig'
+    certificate: '${artifact}.pem'
+    args:
+      - sign-blob
+      - '--output-signature=${signature}'
+      - '--output-certificate=${certificate}'
+      - '--yes' # keyless signing via the workflow's OIDC token, no prompt in CI
+      - '${artifact}'
+    output: true
+
 changelog:
   filters:
     exclude:


### PR DESCRIPTION
signing and attesting release artifacts on every tagged release:

- **cosign keyless signing** — goreleaser `signs` block signs `checksums.txt` (which covers every artifact), uploading `checksums.txt.sig` / `.pem` as release assets
- **GitHub artifact attestations** — `actions/attest-build-provenance` attests all artifacts via `subject-checksums`, verifiable with `gh attestation verify <file> -R katbyte/tctest`
- **SLSA Build L3 provenance** — the `slsa-github-generator` reusable workflow signs provenance in an isolated builder and uploads `multiple.intoto.jsonl` to the release (this is what Scorecard credits for 10/10)

Notes:
- The SLSA builder is pinned by tag (`@v2.1.0`) rather than SHA because it verifies its own ref at runtime and rejects hash references
- Hash export runs before the attest step so a transient attestation failure can't starve the SLSA job of subjects
- Per-job permission elevations (`id-token`, `attestations`) sit on top of the existing restrictive top-level `contents: read`