### PR TITLE
changelog: v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.4.0 (unreleased)
+
+- make the TeamCity API version configurable via `--api-version`/`TCTEST_API_VERSION` instead of hardcoding it ([#122](https://github.com/katbyte/tctest/pull/122))
+- sign releases and attach build provenance: release artifacts are now covered by a cosign keyless signature on `checksums.txt`, GitHub artifact attestations (`gh attestation verify`), and SLSA Build L3 provenance uploaded to the release ([#129](https://github.com/katbyte/tctest/pull/129))
+- ci: add actionlint, shellcheck, and yamllint ([#123](https://github.com/katbyte/tctest/pull/123))
+- ci: restrict workflow token permissions ([#125](https://github.com/katbyte/tctest/pull/125))
+
 ## v1.3.1 (2026-09-02)
 
 - update TeamCity API versions to latest supported by server [#119](https://github.com/katbyte/tctest/pull/119))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## v1.4.0 (unreleased)
+## v1.3.2 (unreleased)
 
 - make the TeamCity API version configurable via `--api-version`/`TCTEST_API_VERSION` instead of hardcoding it ([#122](https://github.com/katbyte/tctest/pull/122))
-- sign releases and attach build provenance: release artifacts are now covered by a cosign keyless signature on `checksums.txt`, GitHub artifact attestations (`gh attestation verify`), and SLSA Build L3 provenance uploaded to the release ([#129](https://github.com/katbyte/tctest/pull/129))
+- sign releases ([#129](https://github.com/katbyte/tctest/pull/129))
 - ci: add actionlint, shellcheck, and yamllint ([#123](https://github.com/katbyte/tctest/pull/123))
 - ci: restrict workflow token permissions ([#125](https://github.com/katbyte/tctest/pull/125))
 


### PR DESCRIPTION
Adds a v1.4.0 section covering everything since v1.3.1:

- `--api-version`/`TCTEST_API_VERSION` (#122)
- signed releases + provenance (#129)
- CI linting (#123) and workflow token permission restrictions (#125)

Left the date as (unreleased) — stamp it when tagging. Skipped the logrus bump (#118) and the codeql test-data config fix (#128) as internal-only, matching how v1.3.0 handled bumps.