### PR TITLE
ci: run depscheck when .tools/** changes

### DIFF
--- a/.github/workflows/pr-depscheck.yaml
+++ b/.github/workflows/pr-depscheck.yaml
@@ -9,6 +9,7 @@ on:
       - '.github/**'
       - '**.go'
       - 'vendor/**'
+      - '.tools/**'
       - '.github/workflows/**'
 
 permissions:


### PR DESCRIPTION
Adds `.tools/**` to the depscheck workflow's path filters so dependency checks also run when tooling changes.