### PR TITLE
ci: fix release signing for cosign v3 bundle format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,12 +70,11 @@ checksum:
 signs:
   - cmd: cosign
     artifacts: checksum # signing checksums.txt covers every artifact it lists
-    signature: '${artifact}.sig'
-    certificate: '${artifact}.pem'
+    # cosign v3 writes a single sigstore bundle (signature + certificate) instead of separate .sig/.pem files
+    signature: '${artifact}.sigstore.json'
     args:
       - sign-blob
-      - '--output-signature=${signature}'
-      - '--output-certificate=${certificate}'
+      - '--bundle=${signature}'
       - '--yes' # keyless signing via the workflow's OIDC token, no prompt in CI
       - '${artifact}'
     output: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## v1.3.3 (2026-09-04)
 
+- fix release signing for the cosign v3 sigstore bundle format: releases now include a `checksums.txt.sigstore.json` bundle ([#133](https://github.com/katbyte/tctest/pull/133))
+
+## v1.3.2 (2026-09-04)
+
 - make the TeamCity API version configurable via `--api-version`/`TCTEST_API_VERSION` instead of hardcoding it ([#122](https://github.com/katbyte/tctest/pull/122))
-- sign releases ([#129](https://github.com/katbyte/tctest/pull/129)); signatures use the cosign v3 sigstore bundle format, `checksums.txt.sigstore.json` ([#133](https://github.com/katbyte/tctest/pull/133))
+- sign releases ([#129](https://github.com/katbyte/tctest/pull/129))
 - ci: add actionlint, shellcheck, and yamllint ([#123](https://github.com/katbyte/tctest/pull/123))
 - ci: restrict workflow token permissions ([#125](https://github.com/katbyte/tctest/pull/125))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## v1.3.2 (2026-09-04)
+## v1.3.3 (2026-09-04)
 
 - make the TeamCity API version configurable via `--api-version`/`TCTEST_API_VERSION` instead of hardcoding it ([#122](https://github.com/katbyte/tctest/pull/122))
-- sign releases ([#129](https://github.com/katbyte/tctest/pull/129))
+- sign releases ([#129](https://github.com/katbyte/tctest/pull/129)); signatures use the cosign v3 sigstore bundle format, `checksums.txt.sigstore.json` ([#133](https://github.com/katbyte/tctest/pull/133))
 - ci: add actionlint, shellcheck, and yamllint ([#123](https://github.com/katbyte/tctest/pull/123))
 - ci: restrict workflow token permissions ([#125](https://github.com/katbyte/tctest/pull/125))
 


### PR DESCRIPTION
The v1.3.2 release run failed at the signing step: cosign-installer v4 ships cosign 3.x, which defaults to the new sigstore bundle format — it ignores `--output-signature`/`--output-certificate` and needs a `--bundle` path, so it tried to write a bundle named "" (`open : no such file or directory`).

The signs block now emits a single `checksums.txt.sigstore.json` bundle (signature + certificate + verification material) via `--bundle=${signature}`. Verify with:

```
cosign verify-blob --bundle checksums.txt.sigstore.json \
  --certificate-identity-regexp 'github.com/katbyte/tctest' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  checksums.txt
```

Reproduced end-to-end locally with goreleaser 2.18.0 (same as the failed run) and cosign v3.1.3 using a test key: the bundle is written, `cosign verify-blob` passes, and goreleaser tracks it as a `Signature` artifact for upload.

Also renames the unshipped v1.3.2 changelog section to v1.3.3 — the v1.3.2 run died before publishing anything, and its tag points at the broken config, so the next release should be tagged v1.3.3.