### PR TITLE
dependabot: check .tools gomod quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,9 @@ updates:
     schedule:
       interval: "weekly"
 
-  # dev tools (actionlint, golangci-lint, gofumpt) pinned in .tools/go.mod
+  # dev tools (actionlint, golangci-lint, gofumpt) pinned in .tools/go.mod; tools move slowly,
+  # so only check quarterly
   - package-ecosystem: "gomod"
     directory: "/.tools"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"


### PR DESCRIPTION
Dev tools (actionlint, golangci-lint, gofumpt) pinned in `.tools/go.mod` move slowly, so switch that dependabot ecosystem from weekly to quarterly checks.