### PR TITLE
ci: add OpenSSF Scorecard badge, lowercase workflow names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 ---
-name: Build
+name: build
 on:
   push:
     branches: [ 'main' ]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: CodeQL
+name: codeQL
 
 on:
   push:

--- a/.github/workflows/pr-depscheck.yaml
+++ b/.github/workflows/pr-depscheck.yaml
@@ -1,5 +1,5 @@
 ---
-name: Vendor Dependencies Check
+name: vendor dependencies check
 on:
   push:
     branches: [ 'main' ]

--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -1,5 +1,5 @@
 ---
-name: GolangCI Lint
+name: golangCI
 on:
   push:
     branches: [ 'main' ]

--- a/.github/workflows/pr-govulncheck.yaml
+++ b/.github/workflows/pr-govulncheck.yaml
@@ -1,5 +1,5 @@
 ---
-name: Go Vulnerability Check
+name: go vulnerability check
 on:
   push:
     branches: [ 'main' ]

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -1,5 +1,5 @@
 ---
-name: Tests
+name: tests
 on:
   push:
     branches: [ 'main' ]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 ---
-name: Release
+name: release
 on:
   push:
     tags: ['v*']

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,4 +1,4 @@
-name: ShellCheck
+name: shellcheck
 on:
   push:
     branches: [ 'main' ]

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -1,4 +1,4 @@
-name: Typos
+name: typos
 
 # Spell checks every file in the repo with typos (config in .typos.toml). Complements the misspell
 # linter in golangci-lint, which only sees Go files.

--- a/.github/workflows/workflow-actionlint.yml
+++ b/.github/workflows/workflow-actionlint.yml
@@ -1,4 +1,4 @@
-name: Workflow Action Lint
+name: workflow action lint
 
 # Lints .github/workflows/ with rhysd/actionlint (expression/context errors, shellcheck on run:
 # blocks, action input validation). actionlint is pinned in .tools/go.mod (built by make) so the

--- a/.github/workflows/workflow-yamllint.yml
+++ b/.github/workflows/workflow-yamllint.yml
@@ -1,4 +1,4 @@
-name: Workflow YAML Lint
+name: workflow YAML lint
 
 # Lints the repo's YAML (workflows, configs) with yamllint; rules live in .yamllint.yml.
 # yamllint is preinstalled on ubuntu-latest and auto-detects GitHub Actions, emitting

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # tctest
 
 [![GitHub release](https://img.shields.io/github/v/release/katbyte/tctest?color=blueviolet)](https://github.com/katbyte/tctest/releases/latest)
-[![Go Version](https://img.shields.io/github/go-mod/go-version/katbyte/tctest?color=00ADD8)](https://github.com/katbyte/tctest/blob/main/go.mod)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/katbyte/tctest?label=go&color=00ADD8)](https://github.com/katbyte/tctest/blob/main/go.mod)
 [![License](https://img.shields.io/github/license/katbyte/tctest?color=blue)](https://github.com/katbyte/tctest/blob/main/LICENSE)
 ![build](https://github.com/katbyte/tctest/actions/workflows/build.yaml/badge.svg)
-![test](https://github.com/katbyte/tctest/actions/workflows/pr-tests.yaml/badge.svg)
 ![lint](https://github.com/katbyte/tctest/actions/workflows/pr-golangci-lint.yaml/badge.svg)
+![CodeQL](https://github.com/katbyte/tctest/actions/workflows/codeql-analysis.yml/badge.svg)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/katbyte/tctest?label=openSSF)](https://scorecard.dev/viewer/?uri=github.com/katbyte/tctest)
 
 A command-line utility to trigger builds in TeamCity to run provider acceptance tests. Given a PR number it can find the files modified, discover the tests to run, and generate a `TEST_PATTERN` automatically.    
 


### PR DESCRIPTION
Adds the [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/katbyte/tctest) badge to the end of the README badge row and arranges the badges and workflow names to match katbyte/terrafmt#119. Scorecard already scans this repo, so the badge renders the current score.